### PR TITLE
Add session management and narration card metadata tracking

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -137,6 +137,40 @@ function registerCoreSettings() {
 
 
 // ─────────────────────────────────────────────────────────────────────────────
+// SESSION ID MANAGEMENT
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Generate or restore a session ID on world load.
+ * Reuses the existing ID when the last session was < 4 hours ago (handles
+ * page reloads mid-session). Otherwise starts a new session, incrementing
+ * sessionNumber and recording the start timestamp.
+ *
+ * Exported for unit testing; called from the ready hook (GM only).
+ */
+export function initSessionId(campaignState) {
+  const last   = campaignState.lastSessionTimestamp;
+  const recent = last && (Date.now() - new Date(last)) < 4 * 3_600_000;
+
+  if (campaignState.currentSessionId && recent) {
+    console.log(`${MODULE_ID} | Resuming session: ${campaignState.currentSessionId}`);
+    return campaignState;
+  }
+
+  campaignState.currentSessionId    = foundry.utils.randomID();
+  campaignState.sessionNumber       = (campaignState.sessionNumber ?? 0) + 1;
+  campaignState.lastSessionTimestamp = new Date().toISOString();
+
+  console.log(
+    `${MODULE_ID} | New session: ${campaignState.currentSessionId} ` +
+    `(#${campaignState.sessionNumber})`
+  );
+
+  return campaignState;
+}
+
+
+// ─────────────────────────────────────────────────────────────────────────────
 // CHAT MESSAGE HOOK — MOVE INTERPRETATION PIPELINE
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -385,6 +419,15 @@ Hooks.once("init", () => {
 Hooks.once("ready", () => {
   console.log(`${MODULE_ID} | Ready`);
 
+  // Session ID — GM writes to world-scoped settings; players read from state
+  if (game.user.isGM) {
+    const campaignState = game.settings.get(MODULE_ID, "campaignState");
+    const updated = initSessionId(campaignState);
+    game.settings.set(MODULE_ID, "campaignState", updated).catch(err => {
+      console.error(`${MODULE_ID} | Failed to persist session ID:`, err);
+    });
+  }
+
   // Check proxy health — warn GM if local proxy is not running
   // (On The Forge this always returns true and no warning is shown)
   isLocalProxyReachable().then(reachable => {
@@ -409,6 +452,13 @@ Hooks.once("ready", () => {
   if (game.settings.get(MODULE_ID, "speechInputEnabled")) {
     initSpeechInput();
   }
+});
+
+Hooks.once("closeWorld", async () => {
+  if (!game.user.isGM) return;
+  const campaignState = game.settings.get(MODULE_ID, "campaignState");
+  campaignState.lastSessionTimestamp = new Date().toISOString();
+  await game.settings.set(MODULE_ID, "campaignState", campaignState);
 });
 
 /**

--- a/src/narration/narrator.js
+++ b/src/narration/narrator.js
@@ -61,7 +61,7 @@ export async function narrateResolution(resolution, contextPacket, campaignState
       return null;
     }
 
-    await postNarrationCard(narration, resolution);
+    await postNarrationCard(narration, resolution, campaignState);
     return narration;
 
   } catch (err) {
@@ -75,7 +75,7 @@ export async function narrateResolution(resolution, contextPacket, campaignState
           maxTokens: settings.narrationMaxTokens,
         });
         if (narration?.trim()) {
-          await postNarrationCard(narration, resolution);
+          await postNarrationCard(narration, resolution, campaignState);
           return narration;
         }
       } catch {
@@ -94,10 +94,11 @@ export async function narrateResolution(resolution, contextPacket, campaignState
  * Separated from narrateResolution so integration tests can call it directly.
  *
  * @param {string} narrationText
- * @param {Object} resolution — MoveResolutionSchema
+ * @param {Object} resolution     — MoveResolutionSchema
+ * @param {Object} [campaignState] — CampaignStateSchema (provides session fields)
  * @returns {Promise<ChatMessage>}
  */
-export async function postNarrationCard(narrationText, resolution) {
+export async function postNarrationCard(narrationText, resolution, campaignState) {
   return ChatMessage.create({
     content: `
       <div class="sf-narration-card">
@@ -107,8 +108,15 @@ export async function postNarrationCard(narrationText, resolution) {
     `.trim(),
     flags: {
       [MODULE_ID]: {
-        narrationCard: true,
-        resolutionId:  resolution?._id ?? '',
+        narratorCard:  true,
+        narrationCard: true,                              // kept for backwards compat
+        narrationText: narrationText,
+        sessionId:     campaignState?.currentSessionId ?? null,
+        sessionNumber: campaignState?.sessionNumber     ?? null,
+        moveId:        resolution?.moveId               ?? null,
+        outcome:       resolution?.outcome              ?? null,
+        resolutionId:  resolution?._id                  ?? '',
+        timestamp:     new Date().toISOString(),
       },
     },
   });

--- a/src/schemas.js
+++ b/src/schemas.js
@@ -645,8 +645,16 @@ export const CampaignStateSchema = {
   worldTruthsJournalId: null,   // Parent JournalEntry Foundry ID
   worldTruthsPageId: null,      // JournalEntryPage Foundry ID
 
-  currentSessionId: null,
-  sessionCount: 0,
+  currentSessionId:     "",    // managed by initSessionId() on ready hook
+  sessionNumber:        0,     // increments each new session
+  lastSessionTimestamp: null,  // ISO string, updated on ready and closeWorld
+  sessionCount:         0,
+
+  campaignRecapCache: {
+    text:            "",
+    generatedAt:     null,
+    chronicleLength: 0,
+  },
 
   createdAt: null,
   updatedAt: null,

--- a/src/ui/settingsPanel.js
+++ b/src/ui/settingsPanel.js
@@ -401,6 +401,11 @@ export class SettingsPanelApp extends ApplicationV2 {
   // -----------------------------------------------------------------------
 
   async _prepareContext(_options) {
+    const campaignState = (() => {
+      try { return game.settings.get(MODULE_ID, 'campaignState') ?? {}; }
+      catch { return {}; }
+    })();
+
     return {
       activeTab:             this.#activeTab,
       isGM:                  game.user.isGM,
@@ -419,6 +424,9 @@ export class SettingsPanelApp extends ApplicationV2 {
       narrationModels:       NARRATION_MODELS,
       narrationPerspectives: NARRATION_PERSPECTIVES,
       narrationTones:        NARRATION_TONES,
+      sessionNumber:         campaignState.sessionNumber         ?? 0,
+      currentSessionId:      campaignState.currentSessionId      ?? '',
+      lastSessionTimestamp:  campaignState.lastSessionTimestamp  ?? null,
     };
   }
 
@@ -442,7 +450,7 @@ export class SettingsPanelApp extends ApplicationV2 {
       case 'safety':   paneHtml = this.#renderSafetyPane(context);   break;
       case 'mischief': paneHtml = this.#renderMischiefPane(context); break;
       case 'narrator': paneHtml = this.#renderNarratorPane(context); break;
-      case 'about':    paneHtml = this.#renderAboutPane();           break;
+      case 'about':    paneHtml = this.#renderAboutPane(context);    break;
     }
 
     const html = `
@@ -616,7 +624,15 @@ export class SettingsPanelApp extends ApplicationV2 {
     `;
   }
 
-  #renderAboutPane() {
+  #renderAboutPane(ctx = {}) {
+    const sessionLabel = ctx.sessionNumber
+      ? `#${ctx.sessionNumber} — ${ctx.currentSessionId ? ctx.currentSessionId.slice(0, 8) : 'not started'}`
+      : 'not started';
+
+    const sessionStarted = ctx.lastSessionTimestamp
+      ? new Date(ctx.lastSessionTimestamp).toLocaleString()
+      : '—';
+
     return `
       <div class="about-pane">
         <h3 class="about-module-name">Starforged Companion</h3>
@@ -624,6 +640,14 @@ export class SettingsPanelApp extends ApplicationV2 {
           Move interpretation, narration, entity tracking, and art generation for Ironsworn: Starforged.
         </p>
         <dl class="about-fields">
+          <div class="about-field">
+            <dt>Current session</dt>
+            <dd>${sessionLabel}</dd>
+          </div>
+          <div class="about-field">
+            <dt>Session started</dt>
+            <dd>${sessionStarted}</dd>
+          </div>
           <div class="about-field">
             <dt>Move AI</dt>
             <dd>claude-haiku-4-5-20251001 · system prompt cached</dd>

--- a/tests/unit /sessionManagement.test.js
+++ b/tests/unit /sessionManagement.test.js
@@ -1,0 +1,132 @@
+/**
+ * STARFORGED COMPANION
+ * tests/unit/sessionManagement.test.js
+ *
+ * Unit tests for initSessionId() (src/index.js) and CampaignStateSchema
+ * session-related fields (src/schemas.js).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { initSessionId } from '../../src/index.js';
+import { CampaignStateSchema } from '../../src/schemas.js';
+
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HELPERS
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeState(overrides = {}) {
+  return {
+    currentSessionId:     '',
+    sessionNumber:        0,
+    lastSessionTimestamp: null,
+    ...overrides,
+  };
+}
+
+/** ISO string for a timestamp N hours in the past */
+function hoursAgo(n) {
+  return new Date(Date.now() - n * 3_600_000).toISOString();
+}
+
+
+// ─────────────────────────────────────────────────────────────────────────────
+// initSessionId()
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('initSessionId()', () => {
+  it('generates a new sessionId when none exists', () => {
+    const state = makeState();
+    const result = initSessionId(state);
+    expect(result.currentSessionId).toBeTruthy();
+    expect(typeof result.currentSessionId).toBe('string');
+    expect(result.currentSessionId.length).toBeGreaterThan(0);
+  });
+
+  it('generates a new sessionId when lastSessionTimestamp is more than 4 hours ago', () => {
+    const oldId = 'old-session-id';
+    const state  = makeState({
+      currentSessionId:     oldId,
+      lastSessionTimestamp: hoursAgo(5),
+    });
+    const result = initSessionId(state);
+    expect(result.currentSessionId).not.toBe(oldId);
+    expect(result.currentSessionId.length).toBeGreaterThan(0);
+  });
+
+  it('reuses existing sessionId when lastSessionTimestamp is less than 4 hours ago', () => {
+    const existingId = 'existing-session';
+    const state = makeState({
+      currentSessionId:     existingId,
+      lastSessionTimestamp: hoursAgo(1),
+    });
+    const result = initSessionId(state);
+    expect(result.currentSessionId).toBe(existingId);
+  });
+
+  it('increments sessionNumber on a new session', () => {
+    const state = makeState({ sessionNumber: 3 });
+    const result = initSessionId(state);
+    expect(result.sessionNumber).toBe(4);
+  });
+
+  it('increments from 0 when sessionNumber is missing', () => {
+    const state = { currentSessionId: '', lastSessionTimestamp: null };
+    const result = initSessionId(state);
+    expect(result.sessionNumber).toBe(1);
+  });
+
+  it('preserves sessionNumber on resume', () => {
+    const state = makeState({
+      currentSessionId:     'abc123',
+      sessionNumber:        7,
+      lastSessionTimestamp: hoursAgo(2),
+    });
+    const result = initSessionId(state);
+    expect(result.sessionNumber).toBe(7);
+  });
+
+  it('sets lastSessionTimestamp on a new session', () => {
+    const before = new Date().toISOString();
+    const state  = makeState();
+    const result = initSessionId(state);
+    expect(result.lastSessionTimestamp).toBeTruthy();
+    expect(new Date(result.lastSessionTimestamp) >= new Date(before)).toBe(true);
+  });
+
+  it('returns the mutated campaignState object', () => {
+    const state  = makeState();
+    const result = initSessionId(state);
+    expect(result).toBe(state);
+  });
+});
+
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CampaignStateSchema — session fields
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('CampaignStateSchema', () => {
+  it('includes currentSessionId field (empty string default)', () => {
+    expect(Object.prototype.hasOwnProperty.call(CampaignStateSchema, 'currentSessionId')).toBe(true);
+    expect(CampaignStateSchema.currentSessionId).toBe('');
+  });
+
+  it('includes sessionNumber field (0 default)', () => {
+    expect(Object.prototype.hasOwnProperty.call(CampaignStateSchema, 'sessionNumber')).toBe(true);
+    expect(CampaignStateSchema.sessionNumber).toBe(0);
+  });
+
+  it('includes lastSessionTimestamp field (null default)', () => {
+    expect(Object.prototype.hasOwnProperty.call(CampaignStateSchema, 'lastSessionTimestamp')).toBe(true);
+    expect(CampaignStateSchema.lastSessionTimestamp).toBeNull();
+  });
+
+  it('includes campaignRecapCache field with expected shape', () => {
+    const cache = CampaignStateSchema.campaignRecapCache;
+    expect(cache).toBeDefined();
+    expect(cache.text).toBe('');
+    expect(cache.generatedAt).toBeNull();
+    expect(cache.chronicleLength).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
This PR implements session management for campaign tracking and enhances narration cards with comprehensive metadata. Sessions are automatically created or resumed based on a 4-hour inactivity threshold, and all narration cards now include session, move, and resolution information for better chronicle tracking.

## Key Changes

- **Session ID Management**: Added `initSessionId()` function that generates new session IDs or resumes existing ones within a 4-hour window, with automatic session number incrementing
- **Session Lifecycle Hooks**: Implemented `ready` hook to initialize sessions on world load (GM only) and `closeWorld` hook to record session end timestamps
- **Campaign State Schema**: Updated to include `currentSessionId`, `sessionNumber`, `lastSessionTimestamp`, and `campaignRecapCache` fields with proper defaults
- **Narration Card Metadata**: Enhanced `postNarrationCard()` to accept `campaignState` and embed session, move, outcome, and timestamp information in chat message flags
- **Settings Panel Display**: Updated About pane to show current session number, ID (truncated), and session start time
- **Unit Tests**: Added comprehensive test suite for `initSessionId()` and schema validation covering session creation, resumption, and edge cases

## Implementation Details

- Session resumption logic uses a 4-hour threshold (`4 * 3_600_000` ms) to handle page reloads and brief disconnections
- Session IDs are generated using Foundry's `foundry.utils.randomID()`
- Narration cards now include backwards-compatible flags with new metadata fields (`narratorCard`, `sessionId`, `sessionNumber`, `moveId`, `outcome`, `timestamp`)
- Session timestamps are recorded as ISO strings for consistency
- GM-only operations ensure session state is persisted to world-scoped settings

https://claude.ai/code/session_019drcvJHQw1mfBGqLbaZa67