### PR TITLE
Refactor actor system data structure to flatten nested properties

### DIFF
--- a/src/character/actorBridge.js
+++ b/src/character/actorBridge.js
@@ -63,24 +63,24 @@ export function readCharacterSnapshot(actor) {
     name:    actor.name,
     actorId: actor.id,
     stats: {
-      edge:   sys.stats?.edge   ?? 0,
-      heart:  sys.stats?.heart  ?? 0,
-      iron:   sys.stats?.iron   ?? 0,
-      shadow: sys.stats?.shadow ?? 0,
-      wits:   sys.stats?.wits   ?? 0,
+      edge:   sys.edge   ?? 0,
+      heart:  sys.heart  ?? 0,
+      iron:   sys.iron   ?? 0,
+      shadow: sys.shadow ?? 0,
+      wits:   sys.wits   ?? 0,
     },
     meters: {
-      health:   meterValue(sys.meters?.health),
-      spirit:   meterValue(sys.meters?.spirit),
-      supply:   meterValue(sys.meters?.supply),
-      momentum: meterValue(sys.meters?.momentum),
+      health:   meterValue(sys.health),
+      spirit:   meterValue(sys.spirit),
+      supply:   meterValue(sys.supply),
+      momentum: meterValue(sys.momentum),
     },
     momentumMax:   Math.max(0, 10 - condCount),
     momentumReset: condCount === 0 ? 0 : Math.max(-2, -condCount),
     debilities: debs,
     xp: {
-      value: sys.xp?.value ?? 0,
-      max:   sys.xp?.max   ?? 0,
+      value: sys.xp ?? 0,
+      max:   30,
     },
   };
 
@@ -94,17 +94,23 @@ export function readCharacterSnapshot(actor) {
  * @returns {Object}
  */
 export function readDebilities(actor) {
-  const d = actor?.system?.debilities ?? {};
+  const d = actor?.system?.debility ?? {};
   return {
-    corrupted:  !!d.corrupted,
-    cursed:     !!d.cursed,
-    tormented:  !!d.tormented,
-    wounded:    !!d.wounded,
-    shaken:     !!d.shaken,
-    unprepared: !!d.unprepared,
-    encumbered: !!d.encumbered,
-    maimed:     !!d.maimed,
-    haunted:    !!d.haunted,
+    corrupted:         !!d.corrupted,
+    cursed:            !!d.cursed,
+    tormented:         !!d.tormented,
+    wounded:           !!d.wounded,
+    shaken:            !!d.shaken,
+    unprepared:        !!d.unprepared,
+    encumbered:        !!d.encumbered,
+    maimed:            !!d.maimed,
+    permanentlyharmed: !!d.permanentlyharmed,
+    traumatized:       !!d.traumatized,
+    doomed:            !!d.doomed,
+    indebted:          !!d.indebted,
+    battered:          !!d.battered,
+    custom1:           !!d.custom1,
+    custom2:           !!d.custom2,
   };
 }
 
@@ -134,33 +140,33 @@ export async function applyMeterChanges(actor, meterChanges) {
   const healthMax  = debs.wounded ? 4 : 5;
   const spiritMax  = debs.shaken  ? 3 : 5;
 
-  const currentHealth   = meterValue(sys.meters?.health);
-  const currentSpirit   = meterValue(sys.meters?.spirit);
-  const currentSupply   = meterValue(sys.meters?.supply);
-  const currentMomentum = meterValue(sys.meters?.momentum);
+  const currentHealth   = meterValue(sys.health);
+  const currentSpirit   = meterValue(sys.spirit);
+  const currentSupply   = meterValue(sys.supply);
+  const currentMomentum = meterValue(sys.momentum);
 
   const updates = {};
 
   if (meterChanges.health !== undefined && meterChanges.health !== 0) {
     const next = clamp(currentHealth + meterChanges.health, 0, healthMax);
-    updates['system.meters.health.value'] = next;
+    updates['system.health.value'] = next;
   }
 
   if (meterChanges.spirit !== undefined && meterChanges.spirit !== 0) {
     const next = clamp(currentSpirit + meterChanges.spirit, 0, spiritMax);
-    updates['system.meters.spirit.value'] = next;
+    updates['system.spirit.value'] = next;
   }
 
   if (meterChanges.supply !== undefined && meterChanges.supply !== 0) {
     const next = clamp(currentSupply + meterChanges.supply, 0, 5);
-    updates['system.meters.supply.value'] = next;
+    updates['system.supply.value'] = next;
   }
 
   if (meterChanges.momentum !== undefined && meterChanges.momentum !== 0) {
     const next = clamp(currentMomentum + meterChanges.momentum, momentumReset, momentumMax);
-    updates['system.meters.momentum.value']  = next;
-    updates['system.meters.momentum.max']    = momentumMax;
-    updates['system.meters.momentum.reset']  = momentumReset;
+    updates['system.momentum.value']      = next;
+    updates['system.momentum.max']        = momentumMax;
+    updates['system.momentum.resetValue'] = momentumReset;
   }
 
   if (Object.keys(updates).length) {
@@ -180,7 +186,7 @@ export async function applyMeterChanges(actor, meterChanges) {
 export async function setDebility(actor, debilityKey, value) {
   if (!actor) return;
 
-  await actor.update({ [`system.debilities.${debilityKey}`]: value });
+  await actor.update({ [`system.debility.${debilityKey}`]: value });
   invalidateActorCache(actor.id);
 
   if (CONDITION_DEBILITIES.includes(debilityKey)) {
@@ -198,12 +204,12 @@ export async function awardXP(actor, amount) {
   if (!actor || amount <= 0) return;
 
   const sys    = actor.system ?? {};
-  const current = sys.xp?.value ?? 0;
-  const max     = sys.xp?.max   ?? 30;
+  const current = sys.xp ?? 0;
+  const max     = 30;
   const next    = Math.min(current + amount, max);
 
   if (next !== current) {
-    await actor.update({ 'system.xp.value': next });
+    await actor.update({ 'system.xp': next });
     invalidateActorCache(actor.id);
   }
 }
@@ -281,15 +287,15 @@ export async function recalculateMomentumBounds(actor) {
   const condCount = countConditionDebilities(debs);
   const maxMom    = Math.max(0, 10 - condCount);
   const resetMom  = condCount === 0 ? 0 : Math.max(-2, -condCount);
-  const current   = meterValue(actor.system?.meters?.momentum);
+  const current   = meterValue(actor.system?.momentum);
   const clamped   = clamp(current, resetMom, maxMom);
 
   const updates = {
-    'system.meters.momentum.max':   maxMom,
-    'system.meters.momentum.reset': resetMom,
+    'system.momentum.max':        maxMom,
+    'system.momentum.resetValue': resetMom,
   };
   if (clamped !== current) {
-    updates['system.meters.momentum.value'] = clamped;
+    updates['system.momentum.value'] = clamped;
   }
 
   await actor.update(updates);

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -182,29 +182,32 @@ global.game.user.character = null;
 
 global.makeTestActor = (overrides = {}) => {
   const updateHistory = [];
+  const sys = overrides.system ?? {};
   const actor = {
     id: overrides.id ?? foundry.utils.randomID(),
     name: overrides.name ?? 'Test Character',
     type: overrides.type ?? 'character',
     hasPlayerOwner: overrides.hasPlayerOwner ?? true,
     system: {
-      stats: {
-        edge: 2, heart: 2, iron: 3, shadow: 1, wits: 2,
-        ...(overrides.system?.stats ?? {}),
-      },
-      meters: {
-        health:   { value: 5, max: 5,  ...(overrides.system?.meters?.health   ?? {}) },
-        spirit:   { value: 5, max: 5,  ...(overrides.system?.meters?.spirit   ?? {}) },
-        supply:   { value: 3, max: 5,  ...(overrides.system?.meters?.supply   ?? {}) },
-        momentum: { value: 2, max: 10, reset: 2, ...(overrides.system?.meters?.momentum ?? {}) },
-      },
-      debilities: {
+      edge:   sys.edge   ?? 2,
+      heart:  sys.heart  ?? 2,
+      iron:   sys.iron   ?? 3,
+      shadow: sys.shadow ?? 1,
+      wits:   sys.wits   ?? 2,
+      health:   { value: 5, max: 5,  min: 0,  ...(sys.health   ?? {}) },
+      spirit:   { value: 5, max: 5,  min: 0,  ...(sys.spirit   ?? {}) },
+      supply:   { value: 3, max: 5,  min: 0,  ...(sys.supply   ?? {}) },
+      momentum: { value: 2, max: 10, min: -6, resetValue: 2, ...(sys.momentum ?? {}) },
+      debility: {
         corrupted: false, cursed: false, tormented: false,
         wounded: false, shaken: false, unprepared: false,
-        encumbered: false, maimed: false, haunted: false,
-        ...(overrides.system?.debilities ?? {}),
+        encumbered: false, maimed: false,
+        permanentlyharmed: false, traumatized: false,
+        doomed: false, indebted: false, battered: false,
+        custom1: false, custom2: false,
+        ...(sys.debility ?? {}),
       },
-      xp: { value: 0, max: 30, ...(overrides.system?.xp ?? {}) },
+      xp: sys.xp ?? 0,
     },
     items: {
       find: (fn) => null,

--- a/tests/unit /actorBridge.test.js
+++ b/tests/unit /actorBridge.test.js
@@ -105,13 +105,11 @@ describe('readCharacterSnapshot', () => {
   it('returns all stats and meters', () => {
     const actor = freshActor({
       system: {
-        stats: { edge: 1, heart: 2, iron: 3, shadow: 4, wits: 2 },
-        meters: {
-          health:   { value: 4, max: 5 },
-          spirit:   { value: 3, max: 5 },
-          supply:   { value: 2, max: 5 },
-          momentum: { value: 5, max: 10, reset: 2 },
-        },
+        edge: 1, heart: 2, iron: 3, shadow: 4, wits: 2,
+        health:   { value: 4, max: 5 },
+        spirit:   { value: 3, max: 5 },
+        supply:   { value: 2, max: 5 },
+        momentum: { value: 5, max: 10, resetValue: 2 },
       },
     });
 
@@ -125,7 +123,7 @@ describe('readCharacterSnapshot', () => {
 
   it('returns debilities as flat boolean map', () => {
     const actor = freshActor({
-      system: { debilities: { wounded: true, shaken: false } },
+      system: { debility: { wounded: true, shaken: false } },
     });
     const snap = readCharacterSnapshot(actor);
     expect(snap.debilities.wounded).toBe(true);
@@ -146,7 +144,7 @@ describe('readCharacterSnapshot', () => {
 
   it('calculates momentumMax from condition debility count', () => {
     const actor = freshActor({
-      system: { debilities: { wounded: true, shaken: true } },
+      system: { debility: { wounded: true, shaken: true } },
     });
     const snap = readCharacterSnapshot(actor);
     expect(snap.momentumMax).toBe(8); // 10 - 2
@@ -154,7 +152,7 @@ describe('readCharacterSnapshot', () => {
 
   it('calculates momentumReset correctly (0 - debility count, min -2)', () => {
     const actor = freshActor({
-      system: { debilities: { wounded: true, shaken: true, unprepared: true } },
+      system: { debility: { wounded: true, shaken: true, unprepared: true } },
     });
     const snap = readCharacterSnapshot(actor);
     expect(snap.momentumReset).toBe(-2); // max(-2, -3) = -2
@@ -174,7 +172,7 @@ describe('readCharacterSnapshot', () => {
 
 describe('readDebilities', () => {
   it('returns all debility keys as booleans', () => {
-    const actor = freshActor({ system: { debilities: { wounded: true, cursed: true } } });
+    const actor = freshActor({ system: { debility: { wounded: true, cursed: true } } });
     const debs  = readDebilities(actor);
 
     expect(debs.wounded).toBe(true);
@@ -185,7 +183,7 @@ describe('readDebilities', () => {
 
   it('coerces truthy values to boolean', () => {
     const actor = { id: 'coerce', name: 'X', type: 'character', hasPlayerOwner: true,
-      system: { debilities: { wounded: 1, shaken: 0 } } };
+      system: { debility: { wounded: 1, shaken: 0 } } };
     invalidateActorCache('coerce');
     const debs = readDebilities(actor);
     expect(debs.wounded).toBe(true);
@@ -200,23 +198,23 @@ describe('readDebilities', () => {
 
 describe('applyMeterChanges', () => {
   it('clamps health to 0–5 for undebilitated actor', async () => {
-    const actor = freshActor({ system: { meters: { health: { value: 5, max: 5 } } } });
+    const actor = freshActor({ system: { health: { value: 5, max: 5 } } });
     await applyMeterChanges(actor, { health: 3 });
     const update = actor._updateHistory[0];
-    expect(update['system.meters.health.value']).toBe(5); // capped at 5
+    expect(update['system.health.value']).toBe(5); // capped at 5
   });
 
   it('applies negative health change', async () => {
-    const actor = freshActor({ system: { meters: { health: { value: 5, max: 5 } } } });
+    const actor = freshActor({ system: { health: { value: 5, max: 5 } } });
     await applyMeterChanges(actor, { health: -2 });
-    expect(actor._updateHistory[0]['system.meters.health.value']).toBe(3);
+    expect(actor._updateHistory[0]['system.health.value']).toBe(3);
   });
 
   it('clamps health to 4 max when wounded is active', async () => {
     const actor = freshActor({
       system: {
-        meters: { health: { value: 5, max: 5 } },
-        debilities: { wounded: true },
+        health: { value: 5, max: 5 },
+        debility: { wounded: true },
       },
     });
     await applyMeterChanges(actor, { health: 0 }); // no change, but clamp applied
@@ -224,57 +222,57 @@ describe('applyMeterChanges', () => {
     // Apply +1 to a wounded character at health 4 — should stay at 4
     const actor2 = freshActor({
       system: {
-        meters: { health: { value: 4, max: 5 } },
-        debilities: { wounded: true },
+        health: { value: 4, max: 5 },
+        debility: { wounded: true },
       },
     });
     await applyMeterChanges(actor2, { health: 2 });
-    expect(actor2._updateHistory[0]['system.meters.health.value']).toBe(4);
+    expect(actor2._updateHistory[0]['system.health.value']).toBe(4);
   });
 
   it('clamps spirit to 3 max when shaken', async () => {
     const actor = freshActor({
       system: {
-        meters: { spirit: { value: 3, max: 5 } },
-        debilities: { shaken: true },
+        spirit: { value: 3, max: 5 },
+        debility: { shaken: true },
       },
     });
     await applyMeterChanges(actor, { spirit: 3 });
-    expect(actor._updateHistory[0]['system.meters.spirit.value']).toBe(3);
+    expect(actor._updateHistory[0]['system.spirit.value']).toBe(3);
   });
 
   it('clamps supply to 0–5', async () => {
-    const actor = freshActor({ system: { meters: { supply: { value: 1, max: 5 } } } });
+    const actor = freshActor({ system: { supply: { value: 1, max: 5 } } });
     await applyMeterChanges(actor, { supply: -5 });
-    expect(actor._updateHistory[0]['system.meters.supply.value']).toBe(0);
+    expect(actor._updateHistory[0]['system.supply.value']).toBe(0);
   });
 
   it('clamps momentum to momentumReset–momentumMax', async () => {
     // With 2 condition debilities: max = 8, reset = -2
     const actor = freshActor({
       system: {
-        meters: { momentum: { value: 2, max: 10, reset: 2 } },
-        debilities: { wounded: true, shaken: true },
+        momentum: { value: 2, max: 10, resetValue: 2 },
+        debility: { wounded: true, shaken: true },
       },
     });
     // Try to set momentum to +20 (above max)
     await applyMeterChanges(actor, { momentum: 20 });
-    expect(actor._updateHistory[0]['system.meters.momentum.value']).toBe(8);
+    expect(actor._updateHistory[0]['system.momentum.value']).toBe(8);
   });
 
   it('reduces momentumMax by 1 per active condition debility', async () => {
     const actor = freshActor({
       system: {
-        meters: { momentum: { value: 2, max: 10, reset: 2 } },
-        debilities: { wounded: true, shaken: true, unprepared: true },
+        momentum: { value: 2, max: 10, resetValue: 2 },
+        debility: { wounded: true, shaken: true, unprepared: true },
       },
     });
     await applyMeterChanges(actor, { momentum: 1 });
-    expect(actor._updateHistory[0]['system.meters.momentum.max']).toBe(7);
+    expect(actor._updateHistory[0]['system.momentum.max']).toBe(7);
   });
 
   it('does not call actor.update() if no changes', async () => {
-    const actor = freshActor({ system: { meters: { health: { value: 5, max: 5 } } } });
+    const actor = freshActor({ system: { health: { value: 5, max: 5 } } });
     await applyMeterChanges(actor, { health: 0 });
     expect(actor._updateHistory).toHaveLength(0);
   });
@@ -293,13 +291,13 @@ describe('setDebility', () => {
   it('sets debility flag on actor', async () => {
     const actor = freshActor();
     await setDebility(actor, 'wounded', true);
-    expect(actor._updateHistory[0]['system.debilities.wounded']).toBe(true);
+    expect(actor._updateHistory[0]['system.debility.wounded']).toBe(true);
   });
 
   it('triggers momentum recalculation for condition debilities', async () => {
     const actor = freshActor({
       system: {
-        meters: { momentum: { value: 9, max: 10, reset: 2 } },
+        momentum: { value: 9, max: 10, resetValue: 2 },
       },
     });
     await setDebility(actor, 'wounded', true);
@@ -318,16 +316,16 @@ describe('setDebility', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('awardXP', () => {
-  it('increments xp.value on actor', async () => {
-    const actor = freshActor({ system: { xp: { value: 4, max: 30 } } });
+  it('increments xp on actor', async () => {
+    const actor = freshActor({ system: { xp: 4 } });
     await awardXP(actor, 2);
-    expect(actor._updateHistory[0]['system.xp.value']).toBe(6);
+    expect(actor._updateHistory[0]['system.xp']).toBe(6);
   });
 
-  it('does not exceed xp.max', async () => {
-    const actor = freshActor({ system: { xp: { value: 28, max: 30 } } });
+  it('does not exceed xp max (30)', async () => {
+    const actor = freshActor({ system: { xp: 28 } });
     await awardXP(actor, 5);
-    expect(actor._updateHistory[0]['system.xp.value']).toBe(30);
+    expect(actor._updateHistory[0]['system.xp']).toBe(30);
   });
 
   it('does not call update if amount is zero or negative', async () => {


### PR DESCRIPTION
## Summary
This PR refactors the actor system data structure to flatten deeply nested properties, improving code readability and reducing accessor complexity throughout the codebase.

## Key Changes

- **Stats structure**: Moved from `system.stats.{stat}` to `system.{stat}` (e.g., `system.stats.edge` → `system.edge`)
- **Meters structure**: Moved from `system.meters.{meter}.value` to `system.{meter}.value` (e.g., `system.meters.health.value` → `system.health.value`)
- **Debilities structure**: Renamed `system.debilities` to `system.debility` and updated all references
- **XP structure**: Simplified from `system.xp.value` to `system.xp` (scalar value instead of object)
- **Momentum reset property**: Renamed from `reset` to `resetValue` for clarity
- **Debility expansion**: Added new debility types (`permanentlyharmed`, `traumatized`, `doomed`, `indebted`, `battered`, `custom1`, `custom2`) and removed deprecated ones (`haunted`)

## Implementation Details

- Updated all accessor patterns in `readCharacterSnapshot()`, `readDebilities()`, `applyMeterChanges()`, `setDebility()`, `awardXP()`, and `recalculateMomentumBounds()`
- Removed unnecessary optional chaining (`?.`) in favor of direct property access where applicable
- Updated test fixtures and assertions to match the new flattened structure
- Maintained backward compatibility in default value handling with nullish coalescing operators
- XP now has a hardcoded max of 30 instead of being configurable per actor

https://claude.ai/code/session_018ieiQ1RKuSPskkN9QZaQkL