### PR TITLE
Filter system messages and improve meter change logging

### DIFF
--- a/src/character/actorBridge.js
+++ b/src/character/actorBridge.js
@@ -170,6 +170,7 @@ export async function applyMeterChanges(actor, meterChanges) {
   }
 
   if (Object.keys(updates).length) {
+    console.log(`actorBridge | applyMeterChanges update:`, updates);
     await actor.update(updates);
     invalidateActorCache(actor.id);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -304,12 +304,19 @@ function isPlayerNarration(message) {
   if (message.flags?.[MODULE_ID]?.moveResolution) return false;
   if (message.flags?.[MODULE_ID]?.narrationCard)  return false;
 
+  // Ironsworn system messages posted by sendToChat() in chat-alert.ts
+  if (message.flags?.['foundry-ironsworn']) return false;
+  if (message.speaker?.alias === 'Ironsworn') return false;
+
   // message.author is correct for both v12 and v13.
   // message.user was the old name — accessing it in v13 logs a deprecation warning.
   const user = message.author ?? game.users?.get(message.user);
   if (user?.isGM) return false;
 
   const text = message.content?.trim() ?? "";
+
+  // No meaningful text content — system-generated empty or near-empty messages
+  if (text.length < 10) return false;
 
   // Escape character — prefix with \ to bypass the pipeline entirely
   if (text.startsWith("\\")) return false;


### PR DESCRIPTION
## Summary
This PR improves message filtering to exclude system-generated messages and adds debugging for meter updates.

## Key Changes
- **Enhanced player narration detection** in `src/index.js`:
  - Added filters to exclude Ironsworn system messages (by flag and speaker alias)
  - Added minimum text length check (10 characters) to filter out empty or near-empty system-generated messages
  
- **Added debugging** in `src/character/actorBridge.js`:
  - Added console logging when meter changes are applied to actors for better visibility into update operations

## Implementation Details
The message filtering improvements prevent system-generated chat messages from being processed as player narration, which could cause unwanted side effects. The text length check catches edge cases where messages contain only whitespace or minimal content. The logging addition helps with troubleshooting meter update operations during development.

https://claude.ai/code/session_01C2Qhghryvd62xAuAUXsn4c