### PR TITLE
Add scope index and documentation structure for project navigation

### DIFF
--- a/docs/character-management-scope.md
+++ b/docs/character-management-scope.md
@@ -1,4 +1,7 @@
 # Starforged Companion — Character Management Scope Document
+
+✅ **COMPLETE** — `actorBridge.js`, `chronicle.js`, `chroniclePanel.js`, and tests implemented. Note: field paths in §2 of this document are outdated; corrected schema is in `ironsworn-api-scope.md`.
+
 ## Priority: After narrator implementation
 
 **Dependency:** Narrator feature must be complete before this work begins.

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -1,0 +1,26 @@
+# Starforged Companion — Documentation Files
+
+Reference index for the `docs/` directory. These are developer and contributor
+documents; they are not bundled into the Foundry module zip.
+
+For the full source tree (src/, tests/, proxy/, styles/, etc.) see the root
+`file-structure.md`.
+
+---
+
+## docs/
+
+| File | Purpose |
+|------|---------|
+| [`scope-index.md`](scope-index.md) | **Start here** — single-table status of all feature scopes; dependency graph and next-steps |
+| [`decisions.md`](decisions.md) | Architecture decisions and their rationale; read before changing any constrained pattern |
+| [`known-issues.md`](known-issues.md) | Open bugs, accepted workarounds, and resolved issues |
+| [`narrator-scope.md`](narrator-scope.md) | ✅ Narrator feature — direct Claude narration replacing Loremaster |
+| [`ironsworn-api-scope.md`](ironsworn-api-scope.md) | ✅ actorBridge field path corrections for foundry-ironsworn v1.27.0 |
+| [`character-management-scope.md`](character-management-scope.md) | ✅ Actor bridge, character chronicle, and chronicle UI panel |
+| [`foundations-scope.md`](foundations-scope.md) | 🔄 Session ID management and narrator card metadata |
+| [`scene-interrogation-scope.md`](scene-interrogation-scope.md) | 📋 `@scene` free-form narrator queries |
+| [`previously-on-scope.md`](previously-on-scope.md) | 📋 Session and campaign recap features |
+| [`world-journal-scope.md`](world-journal-scope.md) | 📋 Automatic world-state documentation in Foundry journals |
+| [`session-01.md`](session-01.md) | Example campaign session illustrating the full move pipeline |
+| [`claude-code-quickstart.md`](claude-code-quickstart.md) | Claude Code usage guide for this project |

--- a/docs/foundations-scope.md
+++ b/docs/foundations-scope.md
@@ -1,4 +1,7 @@
 # Starforged Companion — Foundations Scope
+
+🔄 **IN PROGRESS** — session ID management and narrator card flags implemented; README rewrite, help compendium, and `docs/file-structure.md` pending
+
 ## Infrastructure required before scene interrogation, recap, and character management
 
 **Priority:** Immediate — implement before any other pending scopes  

--- a/docs/ironsworn-api-scope.md
+++ b/docs/ironsworn-api-scope.md
@@ -1,4 +1,7 @@
 # Starforged Companion — Ironsworn System API Scope
+
+✅ **COMPLETE** — field path corrections applied to `actorBridge.js` and `tests/setup.js`
+
 ## Correct actorBridge.js based on foundry-ironsworn v1.27.0 source
 
 **Priority:** Immediate — fixes broken character persistence  

--- a/docs/narrator-scope.md
+++ b/docs/narrator-scope.md
@@ -1,4 +1,7 @@
 # Starforged Companion — Narrator Scope Document
+
+✅ **COMPLETE** — implemented, tested, in production
+
 ## Remove Loremaster, implement direct Claude narration
 
 **Status:** Successful Completion  

--- a/docs/previously-on-scope.md
+++ b/docs/previously-on-scope.md
@@ -1,4 +1,7 @@
 # Starforged Companion — "Previously On" Scope Document
+
+📋 **PLANNED** — specified, not yet started
+
 ## Session and campaign recap features
 
 **Priority:** After scene interrogation  

--- a/docs/scene-interrogation-scope.md
+++ b/docs/scene-interrogation-scope.md
@@ -1,4 +1,7 @@
 # Starforged Companion — Scene Interrogation Scope Document
+
+📋 **PLANNED** — specified, not yet started
+
 ## "Tell me more" — Free-form narrator queries
 
 **Priority:** After narrator implementation is stable  

--- a/docs/scope-index.md
+++ b/docs/scope-index.md
@@ -1,0 +1,52 @@
+# Starforged Companion — Scope Index
+
+Single-glance status of all features. Start here every session to orient quickly.
+For detail on any scope, open the linked document.
+
+---
+
+## Status key
+
+| Badge | Meaning |
+|-------|---------|
+| ✅ COMPLETE | Implemented, tested, merged to main |
+| 🔄 IN PROGRESS | Partially implemented or currently active |
+| 📋 PLANNED | Specified, not yet started |
+| 🔧 SUPERSEDED | Replaced — see note |
+
+---
+
+## All scopes
+
+| Scope | Status | Description | Depends on | Blocks |
+|-------|--------|-------------|------------|--------|
+| [Narrator](narrator-scope.md) | ✅ COMPLETE | Direct Claude narration replacing Loremaster; configurable tone, perspective, model | — | Foundations, Scene Interrogation, Previously On |
+| [Ironsworn API](ironsworn-api-scope.md) | ✅ COMPLETE | Corrected `actorBridge.js` field paths for foundry-ironsworn v1.27.0 | — | Character Management |
+| [Character Management](character-management-scope.md) | ✅ COMPLETE | Actor bridge, character chronicle, and chronicle UI panel | Narrator, Ironsworn API | Previously On, World Journal |
+| [Foundations](foundations-scope.md) | 🔄 IN PROGRESS | Session ID management and narrator card metadata; README and help compendium pending | Narrator | Scene Interrogation, Previously On, Character Management, World Journal |
+| [Scene Interrogation](scene-interrogation-scope.md) | 📋 PLANNED | `@scene` prefix routes free-form questions to the narrator without triggering a move | Foundations | Previously On |
+| [Previously On](previously-on-scope.md) | 📋 PLANNED | Session recap (no API call) and campaign recap (Claude, cached); auto-posts at session start | Foundations, Character Management | World Journal |
+| [World Journal](world-journal-scope.md) | 📋 PLANNED | Automatic faction/location/lore/threat documentation in Foundry journal entries | Character Management, Previously On | — |
+
+---
+
+## Dependency graph
+
+```
+Narrator (✅)
+  └─► Foundations (🔄)
+        ├─► Scene Interrogation (📋)
+        │     └─► Previously On (📋)
+        │               └─► World Journal (📋)
+        └─► Character Management (✅) ◄── Ironsworn API (✅)
+                    └─► Previously On (📋)
+                              └─► World Journal (📋)
+```
+
+---
+
+## What to work on next
+
+1. **Complete Foundations** — README rewrite and `packs/help.json` are the remaining pieces; nothing else is blocked on them but they should ship before v1.0.
+2. **Scene Interrogation** — first planned scope; self-contained, depends only on Foundations infrastructure that is already implemented.
+3. **Previously On (session recap)** — no API call required; can be implemented independently of campaign recap.

--- a/docs/world-journal-scope.md
+++ b/docs/world-journal-scope.md
@@ -1,4 +1,7 @@
 # Starforged Companion — World Journal Scope Document
+
+📋 **PLANNED** — specified, not yet started
+
 ## Automatic documentation of world state in Foundry journals
 
 **Priority:** After character management  


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation infrastructure to help developers and contributors quickly understand project status, dependencies, and next steps. Two new index documents provide single-glance orientation and a roadmap for feature implementation.

## Key Changes

- **`docs/scope-index.md`** — New master index providing:
  - Status badges (COMPLETE, IN PROGRESS, PLANNED, SUPERSEDED) for all feature scopes
  - Single-table overview of all scopes with descriptions, dependencies, and blockers
  - ASCII dependency graph showing feature relationships
  - Clear guidance on what to work on next (Foundations completion → Scene Interrogation → Previously On session recap)

- **`docs/file-structure.md`** — New reference guide documenting:
  - Purpose and location of all documentation files in `docs/`
  - Quick links to scope documents with status badges
  - Distinction between developer docs and source tree structure

- **Status headers added to all scope documents** — Each scope document now opens with a status badge and brief completion note:
  - `narrator-scope.md` — ✅ COMPLETE
  - `ironsworn-api-scope.md` — ✅ COMPLETE
  - `character-management-scope.md` — ✅ COMPLETE (with note about outdated field paths)
  - `foundations-scope.md` — 🔄 IN PROGRESS
  - `scene-interrogation-scope.md` — 📋 PLANNED
  - `previously-on-scope.md` — 📋 PLANNED
  - `world-journal-scope.md` — 📋 PLANNED

## Implementation Details

- Status badges use consistent emoji + text format for quick visual scanning
- Dependency table and graph make feature relationships explicit, preventing work on blocked scopes
- "What to work on next" section prioritizes remaining Foundations work before starting Scene Interrogation
- All scope documents remain unchanged in content; headers are purely informational additions

https://claude.ai/code/session_01EidVCNPQZSyedCRLFfgMqX