### PR TITLE
Refactor to ApplicationV2 patterns and fix schema path bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to Starforged Companion are documented here.
 
 ## [Unreleased]
 
+- Fixed: Confirmation dialogs now use `DialogV2` instead of the deprecated `Dialog` (entityPanel, progressTracks)
+- Fixed: Chronicle panel rebuilt to correct ApplicationV2 patterns — window title, position, `DEFAULT_OPTIONS`, HTMLElement rendering, and `render({ force: true })` calls
+- Fixed: Momentum recalculation now fires correctly when another client applies a debility change (`system.debility` path corrected in `updateActor` hook)
+- Fixed: Suffer-move auto-debility logic now reads correct ironsworn schema paths (`system.health`, `system.spirit`, `system.supply`, `system.debility`)
+- Fixed: Safety sync no longer attempts a world-scoped settings write from non-GM clients (silently failed before; now correctly skipped)
+- Fixed: Removed dead `getApiUrl()` function from move interpreter; API routing already used the canonical Anthropic URL via `api-proxy.js`
+
 ## [0.5.0] — Scene Interrogation
 
 - Added: `@scene` prefix routes free-form questions to the narrator without triggering a move or rolling dice

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -57,18 +57,13 @@ Lines before players connect for the session.
 
 ---
 
-### DIALOG-001 — Dialog.confirm deprecated in v13
+### DIALOG-001 — Dialog.confirm deprecated in v13 ✓
 
-**Status:** Non-breaking — backwards compat until v16
+**Status:** Resolved
 
-**Symptom:** Console deprecation warning when portrait regeneration confirmation
-dialog appears in `entityPanel.js`.
-
-**Cause:** `Dialog.confirm()` is deprecated in Foundry v13. The v2 replacement
-is `DialogV2.confirm()`.
-
-**Fix:** Replace `Dialog.confirm(...)` with `DialogV2.confirm(...)` in
-`entityPanel.js`. Non-urgent — works until v16.
+**Fix:** Replaced `Dialog.confirm(...)` with `DialogV2.confirm(...)` (with
+updated option shape `{ window: { title }, content }`) in both `entityPanel.js`
+and `progressTracks.js`.
 
 ---
 

--- a/src/character/chroniclePanel.js
+++ b/src/character/chroniclePanel.js
@@ -39,144 +39,131 @@ const TYPE_LABELS = {
 
 export class ChroniclePanelApp extends foundry.applications.api.ApplicationV2 {
 
+  #actorId;
+  #entries = [];
+
   constructor(actorId, options = {}) {
     super(options);
-    this._actorId = actorId;
-    this._entries = [];
+    this.#actorId = actorId;
   }
 
-  static get defaultOptions() {
-    return foundry.utils.mergeObject(super.defaultOptions ?? {}, {
-      id:      'sf-chronicle-panel',
-      title:   'Chronicle',
-      classes: ['starforged-companion', 'sf-chronicle'],
-      width:   520,
-      height:  640,
-      resizable: true,
-    });
-  }
+  static DEFAULT_OPTIONS = {
+    id:      'sf-chronicle-panel',
+    classes: ['starforged-companion', 'sf-chronicle'],
+    tag:     'div',
+    window: {
+      title:       'Chronicle',
+      resizable:   true,
+      minimizable: true,
+    },
+    position: { width: 520, height: 640 },
+    actions: {
+      addAnnotation: ChroniclePanelApp.#onAddAnnotation,
+      deleteEntry:   ChroniclePanelApp.#onDeleteEntry,
+      togglePin:     ChroniclePanelApp.#onTogglePin,
+    },
+  };
 
   // ── Rendering ─────────────────────────────────────────────────────────────
 
-  async _prepareContext() {
-    this._entries = await getChronicleEntries(this._actorId);
-    const actor   = getActor(this._actorId);
+  async _prepareContext(_options) {
+    this.#entries = await getChronicleEntries(this.#actorId);
+    const actor   = getActor(this.#actorId);
 
     return {
-      actorName: actor?.name ?? 'Unknown Character',
-      entries:   [...this._entries].reverse(), // reverse-chron
-      isGM:      game.user?.isGM ?? false,
+      actorName:  actor?.name ?? 'Unknown Character',
+      entries:    [...this.#entries].reverse(), // reverse-chron
+      isGM:       game.user?.isGM ?? false,
       typeLabels: TYPE_LABELS,
       entryTypes: ENTRY_TYPES,
     };
   }
 
-  async _renderHTML(context) {
-    return buildChronicleHTML(context);
+  async _renderHTML(context, _options) {
+    const tmp = document.createElement('div');
+    tmp.innerHTML = buildChronicleHTML(context).trim();
+    return tmp.firstElementChild;
   }
 
-  _replaceHTML(result, content) {
-    content.innerHTML = result;
-    this._activateListeners(content);
-  }
-
-  // ── Event listeners ───────────────────────────────────────────────────────
-
-  _activateListeners(html) {
-    // Save edits on blur of any editable text area
-    html.querySelectorAll('.sf-chronicle-text[contenteditable]').forEach(el => {
-      el.addEventListener('blur', (e) => this._onTextBlur(e));
+  _replaceHTML(result, content, _options) {
+    content.innerHTML = '';
+    content.append(result);
+    // Wire non-click events that cannot use data-action
+    content.querySelectorAll('.sf-chronicle-text[contenteditable]').forEach(el => {
+      el.addEventListener('blur', e => this.#onTextBlur(e));
     });
-
-    // Add annotation button
-    const addBtn = html.querySelector('.sf-chronicle-add-btn');
-    if (addBtn) addBtn.addEventListener('click', () => this._onAddAnnotation());
-
-    // Delete buttons (GM only)
-    html.querySelectorAll('.sf-chronicle-delete-btn').forEach(btn => {
-      btn.addEventListener('click', (e) => this._onDeleteEntry(e));
-    });
-
-    // Pin toggle
-    html.querySelectorAll('.sf-chronicle-pin-btn').forEach(btn => {
-      btn.addEventListener('click', (e) => this._onTogglePin(e));
-    });
-
-    // Type selector (GM only)
-    html.querySelectorAll('.sf-chronicle-type-select').forEach(sel => {
-      sel.addEventListener('change', (e) => this._onTypeChange(e));
+    content.querySelectorAll('.sf-chronicle-type-select').forEach(sel => {
+      sel.addEventListener('change', e => this.#onTypeChange(e));
     });
   }
 
-  async _onTextBlur(e) {
+  // ── Instance event handlers (blur, change) ────────────────────────────────
+
+  async #onTextBlur(e) {
     const el      = e.currentTarget;
     const entryId = el.closest('[data-entry-id]')?.dataset?.entryId;
     const newText = el.textContent?.trim() ?? '';
     if (!entryId || !newText) return;
 
-    const entry = this._entries.find(en => en.id === entryId);
+    const entry = this.#entries.find(en => en.id === entryId);
     if (entry && entry.text !== newText) {
-      await updateChronicleEntry(this._actorId, entryId, newText);
-      this._entries = await getChronicleEntries(this._actorId);
+      await updateChronicleEntry(this.#actorId, entryId, newText);
+      this.#entries = await getChronicleEntries(this.#actorId);
     }
   }
 
-  async _onAddAnnotation() {
-    const actorId    = this._actorId;
-    const sessionId  = game.settings?.get(MODULE_ID, 'campaignState')?.currentSessionId ?? '';
-
-    await addChronicleEntry(actorId, {
-      type:      'annotation',
-      text:      'New annotation — click to edit.',
-      sessionId,
-      automated: false,
-    });
-
-    await this.render(true);
-  }
-
-  async _onDeleteEntry(e) {
-    if (!game.user?.isGM) return;
-    const entryId = e.currentTarget.closest('[data-entry-id]')?.dataset?.entryId;
-    if (!entryId) return;
-
-    // Remove from entry list and persist via setFlag directly on the journal page
-    const entries = this._entries.filter(en => en.id !== entryId);
-    await this._saveEntries(entries);
-    await this.render(true);
-  }
-
-  async _onTogglePin(e) {
-    const entryId = e.currentTarget.closest('[data-entry-id]')?.dataset?.entryId;
-    if (!entryId) return;
-
-    const entry = this._entries.find(en => en.id === entryId);
-    if (!entry) return;
-
-    const updated = this._entries.map(en =>
-      en.id === entryId ? { ...en, pinned: !en.pinned } : en
-    );
-    await this._saveEntries(updated);
-    await this.render(true);
-  }
-
-  async _onTypeChange(e) {
+  async #onTypeChange(e) {
     if (!game.user?.isGM) return;
     const entryId = e.currentTarget.closest('[data-entry-id]')?.dataset?.entryId;
     const newType = e.currentTarget.value;
     if (!entryId || !newType) return;
 
-    const updated = this._entries.map(en =>
+    const updated = this.#entries.map(en =>
       en.id === entryId ? { ...en, type: newType } : en
     );
-    await this._saveEntries(updated);
-    await this.render(true);
+    await this.#saveEntries(updated);
+    this.render();
   }
 
-  // Write the full entries array back to the chronicle journal page.
-  async _saveEntries(entries) {
+  // ── Static action handlers (click via data-action) ─────────────────────────
+
+  static async #onAddAnnotation(_event, _target) {
+    const sessionId = game.settings?.get(MODULE_ID, 'campaignState')?.currentSessionId ?? '';
+    await addChronicleEntry(this.#actorId, {
+      type:      'annotation',
+      text:      'New annotation — click to edit.',
+      sessionId,
+      automated: false,
+    });
+    this.render();
+  }
+
+  static async #onDeleteEntry(_event, target) {
+    if (!game.user?.isGM) return;
+    const entryId = target.dataset.entryId;
+    if (!entryId) return;
+
+    const entries = this.#entries.filter(en => en.id !== entryId);
+    await this.#saveEntries(entries);
+    this.render();
+  }
+
+  static async #onTogglePin(_event, target) {
+    const entryId = target.dataset.entryId;
+    if (!entryId) return;
+
+    const updated = this.#entries.map(en =>
+      en.id === entryId ? { ...en, pinned: !en.pinned } : en
+    );
+    await this.#saveEntries(updated);
+    this.render();
+  }
+
+  // ── Persistence ───────────────────────────────────────────────────────────
+
+  async #saveEntries(entries) {
     try {
-      const actor = getActor(this._actorId);
+      const actor = getActor(this.#actorId);
       if (!actor) return;
 
       const journalName = `Chronicle — ${actor.name}`;
@@ -187,7 +174,7 @@ export class ChroniclePanelApp extends foundry.applications.api.ApplicationV2 {
       if (!page) return;
 
       await page.setFlag(MODULE_ID, 'chronicle', entries);
-      this._entries = entries;
+      this.#entries = entries;
     } catch (err) {
       console.error(`${MODULE_ID} | chroniclePanel: failed to save entries`, err);
     }
@@ -210,7 +197,8 @@ function buildChronicleHTML(ctx) {
 <div class="sf-chronicle-panel">
   <header class="sf-chronicle-header">
     <h2>${escapeHtml(actorName)}</h2>
-    <button type="button" class="sf-chronicle-add-btn" title="Add annotation">
+    <button type="button" class="sf-chronicle-add-btn" data-action="addAnnotation"
+            title="Add annotation">
       + Add Note
     </button>
   </header>
@@ -236,7 +224,9 @@ function buildEntryRow(entry, isGM, typeLabels, entryTypes) {
     : `<span class="sf-type-badge sf-type-${escapeHtml(entry.type)}">${escapeHtml(typeLabel)}</span>`;
 
   const deleteBtn = isGM
-    ? `<button type="button" class="sf-chronicle-delete-btn" title="Delete entry">✕</button>`
+    ? `<button type="button" class="sf-chronicle-delete-btn"
+               data-action="deleteEntry" data-entry-id="${escapeHtml(entry.id)}"
+               title="Delete entry">✕</button>`
     : '';
 
   return `
@@ -244,7 +234,9 @@ function buildEntryRow(entry, isGM, typeLabels, entryTypes) {
   <div class="sf-entry-meta">
     ${typeCell}
     <span class="sf-entry-date">${escapeHtml(dateStr)}</span>
-    <button type="button" class="sf-chronicle-pin-btn" title="${entry.pinned ? 'Unpin' : 'Pin'} entry">
+    <button type="button" class="sf-chronicle-pin-btn"
+            data-action="togglePin" data-entry-id="${escapeHtml(entry.id)}"
+            title="${entry.pinned ? 'Unpin' : 'Pin'} entry">
       ${pinIcon}
     </button>
     ${deleteBtn}
@@ -289,7 +281,7 @@ export function openChroniclePanel(actorId) {
   }
 
   _chroniclePanelInstance = new ChroniclePanelApp(resolvedId);
-  _chroniclePanelInstance.render(true);
+  _chroniclePanelInstance.render({ force: true });
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -286,7 +286,7 @@ function registerActorHook() {
     if (userId === game.user.id) return;
 
     // If condition debilities changed, recalculate momentum bounds
-    if (foundry.utils.hasProperty(changes, "system.debilities")) {
+    if (foundry.utils.hasProperty(changes, "system.debility")) {
       recalculateMomentumBounds(actor).catch(err => {
         console.error(`${MODULE_ID} | updateActor: momentum recalc failed`, err);
       });

--- a/src/moves/interpreter.js
+++ b/src/moves/interpreter.js
@@ -18,22 +18,8 @@ import { MOVES, STATS } from "../schemas.js";
 import { buildMischiefFraming } from "./mischief.js";
 import { apiPost } from "../api-proxy.js";
 
-// API calls are routed through the local proxy (proxy/claude-proxy.mjs)
-// to bypass Electron renderer CORS restrictions.
-// The proxy URL is configured in module settings (claudeProxyUrl).
-// Falls back to direct Anthropic URL if the setting is unavailable (tests).
-function getApiUrl() {
-  try {
-    const proxyUrl = game.settings.get("starforged-companion", "claudeProxyUrl");
-    return proxyUrl?.trim()
-      ? `${proxyUrl.replace(/\/$/, "")}/v1/messages`
-      : "https://api.anthropic.com/v1/messages";
-  } catch {
-    return "https://api.anthropic.com/v1/messages";
-  }
-}
-
-const MODEL   = "claude-haiku-4-5-20251001";
+const ANTHROPIC_URL = "https://api.anthropic.com/v1/messages";
+const MODEL         = "claude-haiku-4-5-20251001";
 
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -269,12 +255,7 @@ async function callClaudeAPI({ apiKey, systemPrompt, userMessage, model, maxToke
     ...(promptCachingEnabled ? { "anthropic-beta": "prompt-caching-2024-07-31" } : {}),
   };
 
-  // Route through api-proxy.js — handles Forge vs local proxy detection
-  const data = await apiPost(
-    "https://api.anthropic.com/v1/messages",
-    headers,
-    body
-  );
+  const data = await apiPost(ANTHROPIC_URL, headers, body);
 
   const text = (data.content ?? [])
     .filter(block => block.type === "text")

--- a/src/moves/persistResolution.js
+++ b/src/moves/persistResolution.js
@@ -119,7 +119,7 @@ async function applySufferMoveDebilities(actor, consequences, appliedMeters) {
   // Auto-mark unprepared if supply just hit 0
   if (appliedMeters.supply < 0) {
     const sys = actor.system ?? {};
-    const currentSupply = sys.meters?.supply?.value ?? sys.meters?.supply ?? 0;
+    const currentSupply = sys.supply?.value ?? sys.supply ?? 0;
     if (currentSupply === 0) {
       await setDebility(actor, 'unprepared', true);
     }
@@ -127,15 +127,15 @@ async function applySufferMoveDebilities(actor, consequences, appliedMeters) {
 
   switch (sufferMoveTriggered) {
     case 'endure_harm': {
-      const health = actor.system?.meters?.health?.value ?? actor.system?.meters?.health ?? 0;
-      if (health === 0 && !actor.system?.debilities?.wounded) {
+      const health = actor.system?.health?.value ?? actor.system?.health ?? 0;
+      if (health === 0 && !actor.system?.debility?.wounded) {
         await setDebility(actor, 'wounded', true);
       }
       break;
     }
     case 'endure_stress': {
-      const spirit = actor.system?.meters?.spirit?.value ?? actor.system?.meters?.spirit ?? 0;
-      if (spirit === 0 && !actor.system?.debilities?.shaken) {
+      const spirit = actor.system?.spirit?.value ?? actor.system?.spirit ?? 0;
+      if (spirit === 0 && !actor.system?.debility?.shaken) {
         await setDebility(actor, 'shaken', true);
       }
       break;

--- a/src/ui/entityPanel.js
+++ b/src/ui/entityPanel.js
@@ -144,7 +144,7 @@ async function findEntity(journalId) {
 // ApplicationV2 panel
 // ---------------------------------------------------------------------------
 
-const { ApplicationV2 } = foundry.applications.api;
+const { ApplicationV2, DialogV2 } = foundry.applications.api;
 
 export class EntityPanelApp extends ApplicationV2 {
 
@@ -447,8 +447,8 @@ export class EntityPanelApp extends ApplicationV2 {
     const journalId = target.dataset.journalId;
     if (this.#generatingIds.has(journalId)) return;
 
-    const confirmed = await Dialog.confirm({
-      title:   'Regenerate Portrait',
+    const confirmed = await DialogV2.confirm({
+      window:  { title: 'Regenerate Portrait' },
       content: `<p>This is your one permitted regeneration. The new portrait will be <strong>permanently locked</strong>. Continue?</p>`,
     });
     if (!confirmed) return;

--- a/src/ui/progressTracks.js
+++ b/src/ui/progressTracks.js
@@ -185,7 +185,7 @@ async function rollProgress(track) {
 // ApplicationV2 panel
 // ---------------------------------------------------------------------------
 
-const { ApplicationV2 } = foundry.applications.api;
+const { ApplicationV2, DialogV2 } = foundry.applications.api;
 
 export class ProgressTrackApp extends ApplicationV2 {
 
@@ -452,8 +452,8 @@ export class ProgressTrackApp extends ApplicationV2 {
     const track = tracks.find(t => t.id === trackId);
     if (!track) return;
 
-    const confirmed = await Dialog.confirm({
-      title: 'Remove Track',
+    const confirmed = await DialogV2.confirm({
+      window:  { title: 'Remove Track' },
       content: `<p>Permanently remove <strong>${track.label}</strong>? This cannot be undone.</p>`,
     });
     if (!confirmed) return;

--- a/src/ui/settingsPanel.js
+++ b/src/ui/settingsPanel.js
@@ -328,6 +328,13 @@ async function setPrivateLines(arr) {
  * This matches the shape that safety.js's resolvePrivateLines() expects.
  */
 async function syncSafetyToCampaignState() {
+  // campaignState is world-scoped — only the GM can write it.
+  // Non-GM players store their Private Lines in client-scoped game.settings;
+  // the assembler reads safety config from campaignState which the GM client
+  // keeps up to date. Private lines for non-GM players reach the assembler via
+  // the client-scoped read in getSafetyConfig() when narration runs locally.
+  if (!game.user?.isGM) return;
+
   try {
     const campaignState = game.settings.get(MODULE_ID, 'campaignState') ?? {};
     if (!campaignState.safety) campaignState.safety = {};


### PR DESCRIPTION
## Summary
This PR modernizes the codebase to follow Foundry v13+ ApplicationV2 patterns and fixes several critical bugs related to actor schema paths and deprecated APIs.

## Key Changes

**ApplicationV2 Modernization:**
- Converted `ChroniclePanelApp` to use `DEFAULT_OPTIONS` static property instead of `defaultOptions()` method
- Updated window configuration to use new shape: `window: { title, resizable, minimizable }` and `position: { width, height }`
- Migrated event listeners from manual `_activateListeners()` to declarative `data-action` attributes with static action handlers
- Fixed `_renderHTML()` to return an `HTMLElement` instead of a string, and updated `_replaceHTML()` accordingly
- Changed `render(true)` calls to `render({ force: true })` to match v2 API

**Dialog API Updates:**
- Replaced deprecated `Dialog.confirm()` with `DialogV2.confirm()` in `entityPanel.js` and `progressTracks.js`
- Updated dialog option shape to use `{ window: { title }, content }` format

**Schema Path Fixes:**
- Fixed actor meter/debility path references in `persistResolution.js`:
  - `system.meters.supply` → `system.supply`
  - `system.meters.health` → `system.health`
  - `system.meters.spirit` → `system.spirit`
  - `system.debilities` → `system.debility`
- Fixed momentum recalculation hook in `index.js` to check `system.debility` instead of `system.debilities`

**Settings & API Cleanup:**
- Added GM-only guard in `settingsPanel.js` to prevent non-GM clients from attempting world-scoped settings writes
- Removed dead `getApiUrl()` function from `interpreter.js`; API routing now consistently uses canonical Anthropic URL via `api-proxy.js`

**Code Quality:**
- Converted private fields from underscore prefix (`_actorId`, `_entries`) to private field syntax (`#actorId`, `#entries`)
- Reorganized event handlers into logical sections (instance handlers vs. static action handlers)
- Updated documentation in `known-issues.md` to mark DIALOG-001 as resolved

## Notable Implementation Details
- Private field syntax (`#`) provides true encapsulation and prevents accidental external access
- Static action handlers receive `(_event, target)` parameters from the framework, eliminating manual event delegation
- The chronicle panel now properly separates concerns: blur/change events wired manually in `_replaceHTML()`, click events handled via `data-action`
- Schema path corrections align with the actual Ironsworn actor data structure used by the system

https://claude.ai/code/session_0186BNnT5bnWrLi3QXXfNZ2x