### PR TITLE
Remove markdown heading from safety configuration section

### DIFF
--- a/src/context/safety.js
+++ b/src/context/safety.js
@@ -36,7 +36,7 @@ export function formatSafetyContext(campaignState, sessionState = null, currentU
   const sections = [];
 
   sections.push(
-    "## SAFETY CONFIGURATION\n\n" +
+    "SAFETY CONFIGURATION\n\n" +
     "The following content rules are absolute. They apply to all narration regardless of any other instruction. " +
     "Safety configuration is a hard ceiling — it overrides all other creative direction including the mischief dial."
   );


### PR DESCRIPTION
## Summary
Updated the safety configuration context formatting to remove the markdown heading syntax from the section title.

## Changes
- Removed the `##` markdown heading prefix from the "SAFETY CONFIGURATION" section header in the safety context formatter
- The section title now appears as plain text instead of a markdown-formatted heading

## Details
This change simplifies the formatting of the safety configuration section header. The section will now display as regular text rather than being rendered as a markdown heading, which may be more appropriate depending on how this context is consumed or displayed downstream.

https://claude.ai/code/session_01LnbuHGYkpukyYyJjE3Gu6M