### PR TITLE
fix: initialise group.tools as object for Foundry v13 scene controls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -577,50 +577,59 @@ Hooks.once("closeWorld", async () => {
  * getSceneControlButtons — add toolbar buttons for the three UI panels.
  *
  * Foundry v13 changed this hook: controls is now a plain Object keyed by
- * group name rather than an Array. Both formats are handled here.
+ * group name rather than an Array, and group.tools is an object keyed by
+ * tool name rather than an Array. Both formats are handled here.
  */
 Hooks.on("getSceneControlButtons", (controls) => {
   const controlsArray = Array.isArray(controls)
     ? controls
     : Object.values(controls);
 
-  // v12 uses "token", v13 may use "tokens" — check both
-  const group = controlsArray.find(c => c.name === "token" || c.name === "tokens");
+  const group = controlsArray.find(
+    c => c.name === "token" || c.name === "tokens"
+  );
   if (!group) return;
 
-  if (!Array.isArray(group.tools)) group.tools = [];
+  // v13: tools is an object keyed by name (initialise if absent)
+  // v12: tools is an array (use push)
+  function addTool(tool) {
+    if (Array.isArray(group.tools)) {
+      group.tools.push(tool);
+    } else {
+      group.tools ??= {};
+      group.tools[tool.name] = tool;
+    }
+  }
 
-  group.tools.push(
-    {
-      name:    "progressTracks",
-      title:   "Progress Tracks",
-      icon:    "fas fa-tasks",
-      button:  true,
-      onClick: () => openProgressTracks(),
-    },
-    {
-      name:    "entityPanel",
-      title:   "Entities",
-      icon:    "fas fa-users",
-      button:  true,
-      onClick: () => openEntityPanel(),
-    },
-    {
-      name:    "chronicle",
-      title:   "Character Chronicle",
-      icon:    "fas fa-book-open",
-      button:  true,
-      onClick: () => openChroniclePanel(),
-    },
-    {
-      name:    "sfSettings",
-      title:   "Companion Settings",
-      icon:    "fas fa-shield-alt",
-      button:  true,
-      visible: game.user.isGM,
-      onClick: () => openSettingsPanel(),
-    },
-  );
+  addTool({
+    name:    "progressTracks",
+    title:   "Progress Tracks",
+    icon:    "fas fa-tasks",
+    button:  true,
+    onClick: () => openProgressTracks(),
+  });
+  addTool({
+    name:    "entityPanel",
+    title:   "Entities",
+    icon:    "fas fa-users",
+    button:  true,
+    onClick: () => openEntityPanel(),
+  });
+  addTool({
+    name:    "chronicle",
+    title:   "Character Chronicle",
+    icon:    "fas fa-book-open",
+    button:  true,
+    onClick: () => openChroniclePanel(),
+  });
+  addTool({
+    name:    "sfSettings",
+    title:   "Companion Settings",
+    icon:    "fas fa-shield-alt",
+    button:  true,
+    visible: game.user.isGM,
+    onClick: () => openSettingsPanel(),
+  });
 });
 
 /**


### PR DESCRIPTION
In v13, group.tools starts as undefined and must be initialised as an object keyed by tool name — not an array. The previous code initialised it as [] and used push(), which Foundry v13 ignores entirely.

addTool() now branches on Array.isArray(group.tools): array path for v12 compatibility, object-keyed path for v13.

https://claude.ai/code/session_01DEXK43V79n3QQGaGBHJuLh