### PR TITLE
Skip additional message types in player narration detection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -364,6 +364,9 @@ function isPlayerNarration(message) {
   // Skip messages already processed by this module
   if (message.flags?.[MODULE_ID]?.moveResolution) return false;
   if (message.flags?.[MODULE_ID]?.narrationCard)  return false;
+  if (message.flags?.[MODULE_ID]?.sceneResponse)  return false;
+  if (message.flags?.[MODULE_ID]?.recapCard)       return false;
+  if (message.flags?.[MODULE_ID]?.xcardCard)       return false;
 
   // Ironsworn system messages posted by sendToChat() in chat-alert.ts
   if (message.flags?.['foundry-ironsworn']) return false;


### PR DESCRIPTION
## Summary
Extended the `isPlayerNarration()` function to skip additional message types that are already processed by the module, preventing duplicate processing of scene responses, recap cards, and xcard messages.

## Key Changes
- Added three new flag checks to the message filtering logic:
  - `sceneResponse` - Skip messages flagged as scene responses
  - `recapCard` - Skip messages flagged as recap cards
  - `xcardCard` - Skip messages flagged as xcard messages

## Implementation Details
These checks follow the same pattern as the existing `moveResolution` and `narrationCard` flag checks, ensuring consistency in how the module identifies and skips already-processed messages. This prevents the player narration detection logic from incorrectly processing these specialized message types.

https://claude.ai/code/session_01YSpv5adm4DhFXEiPNGbLXX