### PR TITLE
Add debug logging to scene control button registration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -580,10 +580,19 @@ Hooks.once("closeWorld", async () => {
 });
 
 Hooks.on("getSceneControlButtons", (controls) => {
+  console.log(`${MODULE_ID} | getSceneControlButtons fired, keys:`,
+    Object.keys(controls ?? {}));
+
   // v13: controls is an object keyed by group name
   // Access tokens group directly — do not use Object.values or find()
   const tokenControls = controls?.tokens ?? controls?.token;
-  if (!tokenControls) return;
+  console.log(`${MODULE_ID} | tokenControls:`, tokenControls?.name,
+    "tools:", Object.keys(tokenControls?.tools ?? {}));
+
+  if (!tokenControls) {
+    console.warn(`${MODULE_ID} | No token controls found — buttons not registered`);
+    return;
+  }
 
   // v13: tools is an object keyed by tool name
   // Do NOT reassign tokenControls.tools — add keys to whatever is there


### PR DESCRIPTION
## Summary
Added comprehensive debug logging to the `getSceneControlButtons` hook to help diagnose issues with token control button registration.

## Key Changes
- Added console.log to track when the hook fires and what control groups are available
- Added console.log to display token controls information including name and available tools
- Enhanced the early return condition with a console.warn when token controls are not found, making it easier to identify registration failures

## Implementation Details
These logging statements will help developers and users troubleshoot cases where token control buttons fail to register properly. The logs provide visibility into:
- Whether the hook is being triggered
- What control groups are present in the scene controls object
- Whether token controls are successfully located
- What tools are available in the token controls group

https://claude.ai/code/session_012vPzRNLnM98HSaWzdND1Jq