### PR TITLE
Fix scene control button clicks in Foundry v13

### DIFF
--- a/docs/foundry-api-reference.md
+++ b/docs/foundry-api-reference.md
@@ -221,7 +221,28 @@ Hooks.on("createChatMessage", (message, options, userId) => { });
 // Scene controls toolbar
 // IMPORTANT: in v13, `controls` is an Object keyed by group name, NOT an Array
 // Always handle both: Array.isArray(controls) ? controls : Object.values(controls)
+//
+// IMPORTANT: in v13, `button: true` tools registered here do NOT have their
+// `onChange` (or `onClick`) callback invoked when the button is clicked. The
+// onChange mechanism is broken for button tools. Use `getSceneControlButtons`
+// solely for tool registration (so the button appears in the toolbar) and
+// attach the actual click handler via the `renderSceneControls` hook below.
 Hooks.on("getSceneControlButtons", (controls) => { });
+
+// Scene controls rendered — attach click listeners to button tools here, since
+// `onChange` does not fire for `button: true` tools in v13. The `html` argument
+// is a plain HTMLElement (not jQuery). Buttons are queried via [data-tool="<name>"].
+//
+// Replace each button with a clone before adding the listener so re-renders do
+// not stack duplicate handlers.
+Hooks.on("renderSceneControls", (app, html) => {
+  const root = html instanceof HTMLElement ? html : html[0];
+  const btn = root?.querySelector(`[data-tool="myTool"]`);
+  if (!btn) return;
+  btn.replaceWith(btn.cloneNode(true));
+  root.querySelector(`[data-tool="myTool"]`)
+      ?.addEventListener("click", (e) => { e.stopPropagation(); /* handler */ });
+});
 
 // Actor updated (any client)
 Hooks.on("updateActor", (actor, changes, options, userId) => { });
@@ -523,6 +544,7 @@ Confirmed changes that have already caused bugs in this codebase.
 | `getSceneControlButtons` hook | `controls` is an Array | `controls` is an Object keyed by group name | ✅ Fixed |
 | `getSceneControlButtons` tools | `onClick` handler | `onChange` handler | ✅ Fixed |
 | `getSceneControlButtons` format | Array push | Object (`controls.tokens.tools.name = {}`) | ✅ Fixed |
+| `getSceneControlButtons` `button: true` tools | `onClick` invoked on click | **Neither `onClick` nor `onChange` fires** — attach listener via `renderSceneControls` after render | ✅ Fixed |
 | jQuery in render hooks | `html` is jQuery object | `html` is plain HTMLElement | ✅ Fixed |
 | `Dialog.confirm()` | Valid | **Deprecated** — use `DialogV2.confirm()`. Works until v16 | ⚠️ Open |
 | `Application` class | Valid | **Deprecated** — use `ApplicationV2`. Works until v16 | ✅ Fixed in our code |

--- a/src/index.js
+++ b/src/index.js
@@ -630,6 +630,33 @@ Hooks.on("getSceneControlButtons", (controls) => {
   };
 });
 
+// Foundry v13 does not invoke onChange for `button: true` tools registered via
+// getSceneControlButtons. Attach click listeners directly after the toolbar
+// renders so the buttons actually do something.
+Hooks.on("renderSceneControls", (app, html) => {
+  const root = html instanceof HTMLElement ? html : html[0];
+  if (!root) return;
+
+  const buttonMap = {
+    progressTracks: () => openProgressTracks(),
+    entityPanel:    () => openEntityPanel(),
+    chronicle:      () => openChroniclePanel(),
+    sfSettings:     () => openSettingsPanel(),
+  };
+
+  for (const [name, handler] of Object.entries(buttonMap)) {
+    const btn = root.querySelector(`[data-tool="${name}"]`);
+    if (!btn) continue;
+    // Replace the node to drop any listeners attached on a previous render.
+    btn.replaceWith(btn.cloneNode(true));
+    const freshBtn = root.querySelector(`[data-tool="${name}"]`);
+    freshBtn?.addEventListener("click", (e) => {
+      e.stopPropagation();
+      handler();
+    });
+  }
+});
+
 /**
  * renderChatLog — inject PTT button when speech is enabled.
  * html is HTMLElement in v13, jQuery object in v12 — injectPushToTalkButton handles both.


### PR DESCRIPTION
## Summary
Foundry v13 broke the `onChange` callback mechanism for `button: true` tools registered via the `getSceneControlButtons` hook. This PR implements a workaround by attaching click listeners directly to toolbar buttons via the `renderSceneControls` hook.

## Changes
- **src/index.js**: Added a `renderSceneControls` hook handler that:
  - Queries for registered button tools by their `data-tool` attribute
  - Clones each button node to remove stale event listeners from previous renders
  - Attaches fresh click handlers that invoke the appropriate panel/track opening functions
  - Prevents event propagation to avoid unintended side effects

- **docs/foundry-api-reference.md**: Updated API reference documentation to:
  - Clarify that `button: true` tools in v13 do not invoke their `onChange`/`onClick` callbacks
  - Document the `renderSceneControls` hook as the correct place to attach button handlers
  - Add a practical code example showing the button cloning pattern
  - Update the compatibility table to reflect this v13 breaking change and its fix

## Implementation Details
The solution uses node cloning to ensure that re-renders of the scene controls toolbar don't accumulate duplicate event listeners. Each render cycle replaces the button with a fresh clone before attaching a new listener, maintaining a 1:1 handler-to-button ratio.

https://claude.ai/code/session_01DUpUWRjmZHhcB6wCUzxgNx