### PR TITLE
Fix narrator integration tests argument order for campaignState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Starforged Companion are documented here.
 
 ## [Unreleased]
 
+- Fixed: Quench narrator integration tests now pass `campaignState` in the correct argument position so the `sessionId` flag on narrator chat cards is verified against a real session ID
 - Changed: Claude API Key and Art Generation API Key are no longer shown in the standard Configure Settings dialog. They are now configured in Companion Settings → About tab and are only visible to the GM.
 - Fixed: All module commands changed to `!` prefix (`!x`, `!recap`) — Foundry v13 rejects unrecognised `/command` patterns before `createChatMessage` fires
 - Fixed: Confirmation dialogs now use `DialogV2` instead of the deprecated `Dialog` (entityPanel, progressTracks)

--- a/src/integration/quench.js
+++ b/src/integration/quench.js
@@ -353,7 +353,7 @@ function registerNarratorTests(quench) {
           const campaignState = game.settings.get("starforged-companion", "campaignState");
           const before = game.messages.size;
 
-          await narrateResolution(sampleResolution, campaignState);
+          await narrateResolution(sampleResolution, {}, campaignState);
 
           assert.isAbove(game.messages.size, before,
             "A narration card should have been posted to chat");
@@ -394,7 +394,7 @@ function registerNarratorTests(quench) {
           const campaignState = game.settings.get("starforged-companion", "campaignState");
           const before = game.messages.size;
 
-          await narrateResolution(sampleResolution, campaignState);
+          await narrateResolution(sampleResolution, {}, campaignState);
 
           // Restore key
           await game.settings.set("starforged-companion", "claudeApiKey", realKey);


### PR DESCRIPTION
## Summary
Fixed the argument order in quench narrator integration tests to correctly pass `campaignState` as the third parameter to `narrateResolution()`, with an empty object as the second parameter.

## Changes
- Updated two test cases in `src/integration/quench.js` that call `narrateResolution()` to pass arguments in the correct order: `narrateResolution(sampleResolution, {}, campaignState)` instead of `narrateResolution(sampleResolution, campaignState)`
- This ensures the `sessionId` flag on narrator chat cards is properly verified against a real session ID during testing

## Details
The `narrateResolution()` function expects three parameters, with the second parameter being an options object and the third being the campaign state. The tests were previously passing `campaignState` as the second argument, which caused the session ID verification to fail. This fix aligns the test calls with the correct function signature.

https://claude.ai/code/session_013B913eQ93mqGWKZdN4D52f