### PR TITLE
Lock canonical sector entities and sync settlement stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Starforged Companion are documented here.
 
 ## [Unreleased]
 
+- Added: Sector-created settlements and connections are now flagged `canonicalLocked` so future narrator-driven entity discovery will not overwrite them
+- Fixed: Sector creator now mirrors each settlement's narrator stub onto the settlement entity record's description, keeping the canonical entity in sync with the sector journal page
 - Added: DALL-E 3 sector background art — each sector gets a generated 1792×1024 landscape image matching its region (Terminus, Outlands, Expanse, Void), with visual modifiers for notable troubles (energy storms, supernova, spatial rifts)
 - Added: Foundry Scene created on sector finalization — background image, Journal Note pins per settlement, Drawing lines for passages; scene is created but not auto-activated
 - Added: Narrator journal stubs — atmospheric one-paragraph descriptions for sector and each settlement generated via Claude Haiku, stored as annotatable journal pages in a sector record JournalEntry

--- a/src/entities/settlement.js
+++ b/src/entities/settlement.js
@@ -42,6 +42,11 @@ export const SettlementSchema = {
   // Linked entities
   connectionIds: [],     // Connection _ids of notable inhabitants
 
+  // Set true when this entity was authored by the sector creator (or any other
+  // canonical source) and should not be overwritten by narrator entity discovery.
+  // No-op until the entity discovery system reads it.
+  canonicalLocked: false,
+
   createdAt: null,
   updatedAt: null,
 };

--- a/src/schemas.js
+++ b/src/schemas.js
@@ -389,6 +389,11 @@ export const ConnectionSchema = {
   // Privacy — per Brief §3: individual player Lines must not be visible to other players
   playerVisible: true,          // false = GM-only record (hidden antagonists, secret NPCs)
 
+  // Set true when this connection was authored by the sector creator (or any
+  // other canonical source) and should not be overwritten by narrator entity
+  // discovery. No-op until the entity discovery system reads it.
+  canonicalLocked: false,
+
   createdAt: null,
   updatedAt: null,
 };

--- a/src/sectors/sectorGenerator.js
+++ b/src/sectors/sectorGenerator.js
@@ -223,13 +223,14 @@ export async function createEntityJournals(sector, campaignState) {
   for (const s of sector.settlements) {
     const beforeLen = campaignState.settlementIds?.length ?? 0;
     await createSettlement({
-      name:       s.name,
-      location:   locationTypeToLabel(s.locationType),
-      population: s.population,
-      authority:  s.authority,
-      projects:   s.projects,
-      trouble:    s.trouble ?? null,
-      planet:     s.planet ?? null,
+      name:            s.name,
+      location:        locationTypeToLabel(s.locationType),
+      population:      s.population,
+      authority:       s.authority,
+      projects:        s.projects,
+      trouble:         s.trouble ?? null,
+      planet:          s.planet ?? null,
+      canonicalLocked: true,
     }, campaignState);
     const journalId = campaignState.settlementIds?.[beforeLen] ?? null;
     settlements[s.id] = journalId
@@ -239,11 +240,12 @@ export async function createEntityJournals(sector, campaignState) {
 
   const connBeforeLen = campaignState.connectionIds?.length ?? 0;
   await createConnection({
-    name:     sector.connection.name,
-    role:     sector.connection.role,
-    goal:     sector.connection.goal,
-    rank:     "dangerous",
-    location: sector.connection.homeSettlement,
+    name:            sector.connection.name,
+    role:            sector.connection.role,
+    goal:            sector.connection.goal,
+    rank:            "dangerous",
+    location:        sector.connection.homeSettlement,
+    canonicalLocked: true,
   }, campaignState);
   const connectionJournalId = campaignState.connectionIds?.[connBeforeLen] ?? null;
 
@@ -268,6 +270,12 @@ export async function storeSector(sector, extras, campaignState) {
     stubs            = { sector: null, settlements: {} },
   } = extras ?? {};
 
+  // Single source of truth: the global lists campaignState.settlementIds and
+  // campaignState.connectionIds are authoritative. Each sector record below
+  // holds a *reference subset* of those same JournalEntry IDs — never a copy
+  // or a parallel ID space. createSettlement()/createConnection() are
+  // responsible for pushing IDs to the global lists; we read the same IDs
+  // back here via `settlements`/`connectionJournalId`.
   const stored = {
     id:                 sector.id,
     name:               sector.name,
@@ -344,6 +352,31 @@ export async function generateNarratorStubs(sector, narratorSettings = {}) {
   }
 
   return { sector: sectorStubText, settlements };
+}
+
+/**
+ * Write each settlement narrator stub into its entity record's `description`
+ * field, so the canonical entity carries the same prose as the sector journal
+ * page. Safe to call when stubs are missing — fields stay untouched.
+ *
+ * @param {Object} settlements — { sourceSettlementId: JournalEntry|null }
+ * @param {{ settlements?: Object }} stubs — output from generateNarratorStubs()
+ * @returns {Promise<void>}
+ */
+export async function applyStubsToSettlementEntities(settlements, stubs) {
+  if (!stubs?.settlements) return;
+  for (const [sourceId, entry] of Object.entries(settlements ?? {})) {
+    const stub = stubs.settlements[sourceId];
+    if (!stub || !entry) continue;
+    const page = entry.pages?.contents?.[0];
+    if (!page) continue;
+    const existing = page.flags?.[MODULE_ID]?.["settlement"] ?? {};
+    try {
+      await page.setFlag(MODULE_ID, "settlement", { ...existing, description: stub });
+    } catch (err) {
+      console.warn(`${MODULE_ID} | Failed to apply stub to settlement entity:`, err);
+    }
+  }
 }
 
 /**

--- a/src/sectors/sectorPanel.js
+++ b/src/sectors/sectorPanel.js
@@ -15,6 +15,7 @@ import {
   createEntityJournals,
   generateNarratorStubs,
   createSectorJournal,
+  applyStubsToSettlementEntities,
 } from "./sectorGenerator.js";
 import { renderSectorMap }         from "./sectorMap.js";
 import { generateSectorBackground } from "./sectorArt.js";
@@ -229,6 +230,10 @@ export class SectorCreatorApp extends ApplicationV2 {
           ? generateNarratorStubs(this.#sector, narratorSettings).catch(() => ({ sector: null, settlements: {} }))
           : Promise.resolve({ sector: null, settlements: {} }),
       ]);
+
+      // Mirror settlement stubs onto the entity records so the canonical
+      // entity description matches what the sector journal page shows.
+      await applyStubsToSettlementEntities(entityData.settlements, stubs);
 
       // Sector journal (needs stubs); scene (needs background + entity journals)
       const [sectorJournal, scene] = await Promise.all([


### PR DESCRIPTION
## Summary
This PR adds safeguards to prevent narrator-driven entity discovery from overwriting sector-created settlements and connections, and ensures settlement narrator stubs are mirrored onto their canonical entity records.

## Key Changes

- **Added `canonicalLocked` flag** to Settlement and Connection schemas to mark entities created by the sector creator as authoritative and protected from future overwrites by narrator entity discovery
- **Set `canonicalLocked: true`** when creating settlements and connections during sector finalization in `createEntityJournals()`
- **New function `applyStubsToSettlementEntities()`** mirrors each settlement's narrator stub description onto the settlement entity record's page flags, keeping the canonical entity in sync with the sector journal page
- **Integrated stub application** into the sector creation workflow in `SectorCreatorApp` to ensure stubs are written to entities before scene/journal creation
- **Added clarifying comment** in `storeSector()` documenting that sector records hold reference subsets of global JournalEntry IDs, not copies

## Implementation Details

- The `canonicalLocked` flag is a no-op until the entity discovery system is implemented to read it
- Settlement stubs are safely applied with error handling and graceful degradation if stubs or entries are missing
- The stub application preserves existing flags while adding/updating the description field
- Code formatting improvements (aligned object properties) for readability in modified functions

https://claude.ai/code/session_01KHKTAKqfaHDosGm6ey6VKK