### PR TITLE
Fix passage IDs and move canonicalLocked to journal flags

### DIFF
--- a/src/integration/quench.js
+++ b/src/integration/quench.js
@@ -649,6 +649,7 @@ function registerSectorCreatorTests(quench) {
 
       describe("generateNarratorStubs (requires Claude API key)", function () {
         it("returns a sector stub string when API key is configured", async function () {
+          this.timeout(30000);
           const apiKey = (() => {
             try { return game.settings.get("starforged-companion", "claudeApiKey"); }
             catch { return null; }

--- a/src/sectors/sectorGenerator.js
+++ b/src/sectors/sectorGenerator.js
@@ -82,9 +82,9 @@ export function generateSector(region, _overrides = {}) {
   const passages = [];
   for (let i = 0; i < cfg.passages; i++) {
     if (settlements[i] && settlements[i + 1]) {
-      passages.push({ fromId: i, toId: i + 1, toEdge: false });
+      passages.push({ fromId: settlements[i].id, toId: settlements[i + 1].id, toEdge: false });
     } else {
-      passages.push({ fromId: i, toId: null, toEdge: true, edgeDirection: "right" });
+      passages.push({ fromId: settlements[i].id, toId: null, toEdge: true, edgeDirection: "right" });
     }
   }
 
@@ -223,31 +223,55 @@ export async function createEntityJournals(sector, campaignState) {
   for (const s of sector.settlements) {
     const beforeLen = campaignState.settlementIds?.length ?? 0;
     await createSettlement({
-      name:            s.name,
-      location:        locationTypeToLabel(s.locationType),
-      population:      s.population,
-      authority:       s.authority,
-      projects:        s.projects,
-      trouble:         s.trouble ?? null,
-      planet:          s.planet ?? null,
-      canonicalLocked: true,
+      name:       s.name,
+      location:   locationTypeToLabel(s.locationType),
+      population: s.population,
+      authority:  s.authority,
+      projects:   s.projects,
+      trouble:    s.trouble ?? null,
+      planet:     s.planet ?? null,
     }, campaignState);
     const journalId = campaignState.settlementIds?.[beforeLen] ?? null;
-    settlements[s.id] = journalId
+    const journalEntry = journalId
       ? ((() => { try { return game.journal?.get(journalId) ?? null; } catch { return null; } })())
       : null;
+    settlements[s.id] = journalEntry;
+    if (journalEntry) {
+      const page = journalEntry.pages?.contents?.[0];
+      if (page) {
+        const existing = page.flags?.[MODULE_ID]?.["settlement"] ?? {};
+        await page.setFlag(MODULE_ID, "settlement", {
+          ...existing,
+          canonicalLocked: true,
+          updatedAt: new Date().toISOString(),
+        });
+      }
+    }
   }
 
   const connBeforeLen = campaignState.connectionIds?.length ?? 0;
   await createConnection({
-    name:            sector.connection.name,
-    role:            sector.connection.role,
-    goal:            sector.connection.goal,
-    rank:            "dangerous",
-    location:        sector.connection.homeSettlement,
-    canonicalLocked: true,
+    name:     sector.connection.name,
+    role:     sector.connection.role,
+    goal:     sector.connection.goal,
+    rank:     "dangerous",
+    location: sector.connection.homeSettlement,
   }, campaignState);
   const connectionJournalId = campaignState.connectionIds?.[connBeforeLen] ?? null;
+  if (connectionJournalId) {
+    try {
+      const connEntry = game.journal?.get(connectionJournalId) ?? null;
+      const connPage  = connEntry?.pages?.contents?.[0];
+      if (connPage) {
+        const existing = connPage.flags?.[MODULE_ID]?.["connection"] ?? {};
+        await connPage.setFlag(MODULE_ID, "connection", {
+          ...existing,
+          canonicalLocked: true,
+          updatedAt: new Date().toISOString(),
+        });
+      }
+    } catch { /* non-Foundry context */ }
+  }
 
   return { settlements, connectionJournalId };
 }


### PR DESCRIPTION
## Summary
This PR fixes passage generation to use settlement IDs instead of array indices, and refactors how the `canonicalLocked` flag is stored by moving it from entity creation parameters to journal entry flags.

## Key Changes

- **Passage ID Fix**: Updated passage generation to use `settlements[i].id` and `settlements[i + 1].id` instead of array indices `i` and `i + 1`. This ensures passages correctly reference settlement entities rather than their position in the array.

- **Canonical Lock Refactoring**: Removed `canonicalLocked: true` from `createSettlement()` and `createConnection()` function calls. Instead, the flag is now set directly on the journal entry's first page using `setFlag()` with the module ID, alongside an `updatedAt` timestamp.

- **Settlement Journal Handling**: Refactored settlement journal creation to store the actual journal entry object instead of just the ID, enabling subsequent flag operations.

- **Connection Journal Handling**: Added proper flag setting for connection journal entries with error handling for non-Foundry contexts.

- **Code Formatting**: Aligned object property formatting in function calls for improved readability.

- **Test Timeout**: Increased timeout for the Claude API narrator stub test to 30 seconds to accommodate API latency.

## Implementation Details

The refactoring moves the `canonicalLocked` state from being set at entity creation time to being stored in the journal entry's flags system. This approach provides better separation of concerns and allows the flag to be updated independently of the entity creation logic. The changes include proper null-checking and error handling to gracefully handle cases where journal entries or pages may not exist.

https://claude.ai/code/session_01SXAiZBWQFbsJGwMPib5BiX