### PR TITLE
Improve error handling and UX for sector art generation

### DIFF
--- a/src/sectors/sceneBuilder.js
+++ b/src/sectors/sceneBuilder.js
@@ -71,25 +71,25 @@ export async function createSectorScene(sector, backgroundPath, entityJournals) 
   const settlements = sector.mapData?.settlements ?? [];
   if (settlements.length) {
     const noteData = settlements.map(s => {
-      const journal = entityJournals?.[s.id] ?? null;
-      const x = (s.gridX + 0.5) * gridCellSize;
-      const y = (s.gridY + 0.5) * gridCellSize;
+      const journal      = entityJournals?.[s.id] ?? null;
+      const locationType = s.locationType ?? s.type;
       return {
         entryId:    journal?.id ?? null,
-        x,
-        y,
-        icon:       "icons/svg/circle.svg",
+        x:          s.gridX * gridCellSize,
+        y:          s.gridY * gridCellSize,
+        icon:       iconPathForLocationType(locationType),
         iconSize:   40,
-        iconTint:   settlementTint(s.type),
+        iconTint:   tintForLocationType(locationType),
         text:       s.name,
-        fontSize:   18,
-        textColor:  "#aabbdd",
+        fontSize:   24,
+        textColor:  "#FFFFFF",
         textAnchor: 1,   // BOTTOM (CONST.TEXT_ANCHOR_POINTS.BOTTOM)
         global:     true,
         flags: {
           [MODULE_ID]: {
+            sectorNote:   true,
             settlementId: s.id,
-            type:         s.type,
+            locationType,
           },
         },
       };
@@ -166,10 +166,18 @@ function makePassageLine(x1, y1, x2, y2, passage, dashed) {
   };
 }
 
-function settlementTint(type) {
-  switch (type) {
-    case "orbital":    return "#88aaff";
-    case "planetside": return "#88ffaa";
-    default:           return "#ffaa88";
+function iconPathForLocationType(locationType) {
+  switch (locationType) {
+    case "orbital":    return "icons/svg/circle.svg";
+    case "planetside": return "icons/svg/target.svg";
+    default:           return "icons/svg/aura.svg";   // deep_space
+  }
+}
+
+function tintForLocationType(locationType) {
+  switch (locationType) {
+    case "orbital":    return "#7EB8F7";   // cool blue — station lights
+    case "planetside": return "#8FCF7E";   // warm green — habitable world
+    default:           return "#C4A45A";   // amber — isolated outpost
   }
 }

--- a/src/sectors/sectorArt.js
+++ b/src/sectors/sectorArt.js
@@ -72,25 +72,43 @@ const TROUBLE_VISUAL_MODIFIERS = {
  * @returns {Promise<string|null>} — Foundry data file path, or null on failure
  */
 export async function generateSectorBackground(sector, _campaignState) {
-  const artApiKey = (() => {
-    try { return game.settings.get(MODULE_ID, "artApiKey"); }
-    catch { return null; }
-  })();
+  const artApiKey = readApiKey();
 
   if (!artApiKey) {
-    console.log(`${MODULE_ID} | sectorArt: no art API key configured, skipping`);
+    console.warn(`${MODULE_ID} | sectorArt: no OpenAI art API key configured — scene will have no background`);
     return null;
   }
 
+  const { prompt, size } = buildSectorBackgroundPrompt(sector);
+
+  let b64;
   try {
-    const { prompt, size } = buildSectorBackgroundPrompt(sector);
-    const b64 = await requestDalleImage(prompt, size, artApiKey);
-    if (!b64) return null;
-    return await uploadSectorImage(b64, sector.id);
+    b64 = await requestDalleImage(prompt, size, artApiKey);
   } catch (err) {
-    console.error(`${MODULE_ID} | sectorArt: generation failed:`, err);
+    console.warn(`${MODULE_ID} | sectorArt: DALL-E API call failed:`, err?.message ?? err);
     return null;
   }
+
+  if (!b64) {
+    console.warn(`${MODULE_ID} | sectorArt: DALL-E returned no image data`);
+    return null;
+  }
+
+  let uploadedPath;
+  try {
+    uploadedPath = await uploadSectorImage(b64, sector.id);
+  } catch (err) {
+    console.warn(`${MODULE_ID} | sectorArt: FilePicker.upload failed:`, err?.message ?? err);
+    return null;
+  }
+
+  if (!uploadedPath) {
+    console.warn(`${MODULE_ID} | sectorArt: upload returned no path`);
+    return null;
+  }
+
+  console.log(`${MODULE_ID} | sectorArt: uploaded background to ${uploadedPath}`);
+  return uploadedPath;
 }
 
 /**
@@ -113,6 +131,16 @@ export function buildSectorBackgroundPrompt(sector) {
 // ─────────────────────────────────────────────────────────────────────────────
 // INTERNALS
 // ─────────────────────────────────────────────────────────────────────────────
+
+// Mirror of readApiKey() in src/art/generator.js — keep these in sync so both
+// sector backgrounds and entity portraits resolve the OpenAI key the same way.
+function readApiKey() {
+  try {
+    return game.settings.get(MODULE_ID, "artApiKey") ?? null;
+  } catch {
+    return null;
+  }
+}
 
 async function requestDalleImage(prompt, size, apiKey) {
   const headers = {
@@ -151,5 +179,5 @@ async function uploadSectorImage(b64, sectorId) {
   const file = new File([blob], filename, { type: "image/png" });
 
   const result = await FilePicker.upload("data", UPLOAD_DIR, file, {}, { notify: false });
-  return result.path ?? `${UPLOAD_DIR}/${filename}`;
+  return result?.path ?? null;
 }


### PR DESCRIPTION
## Summary
Refactored sector background generation to provide better error handling, clearer logging, and improved scene note visualization. The changes separate concerns into distinct steps with explicit validation at each stage, making failures more transparent and easier to debug.

## Key Changes

- **Enhanced error handling**: Replaced single try-catch block with granular error handling for each operation (API call, image upload), providing specific warning messages for different failure modes
- **Extracted `readApiKey()` helper**: Created a dedicated function to read the OpenAI API key, with a comment noting it mirrors the same logic in `src/art/generator.js` for consistency
- **Improved logging**: Changed generic error logs to specific warnings at each failure point, and added success logging when background is uploaded
- **Fixed upload path handling**: Changed `uploadSectorImage()` to return `null` on failure instead of a fallback path, allowing callers to distinguish between success and failure
- **Enhanced scene notes**: 
  - Renamed `settlementTint()` to `tintForLocationType()` for clarity
  - Added `iconPathForLocationType()` to vary settlement icons by type (orbital stations, planetside targets, deep space outposts)
  - Updated icon colors to be more thematic (cool blue for stations, warm green for habitable worlds, amber for outposts)
  - Adjusted note positioning to use grid cell corners instead of centers
  - Increased font size (18→24) and changed text color to white for better visibility
  - Added `sectorNote` flag to distinguish settlement notes from other scene notes

## Implementation Details

The refactored `generateSectorBackground()` now follows a clear pipeline:
1. Read and validate API key
2. Build prompt and request image from DALL-E
3. Upload image to Foundry
4. Return path or null with appropriate logging at each step

This makes it easier to identify where failures occur and provides better user feedback through console warnings.

https://claude.ai/code/session_01KCcbpqzEUT3NCvuxvw6TeR