### PR TITLE
Fix Foundry v13 compatibility and improve test cleanup

### DIFF
--- a/src/entities/connection.js
+++ b/src/entities/connection.js
@@ -75,6 +75,7 @@ export async function createConnection(data, campaignState) {
   }]);
 
   // Register in campaign state
+  if (!campaignState.connectionIds) campaignState.connectionIds = [];
   if (!campaignState.connectionIds.includes(entry.id)) {
     campaignState.connectionIds.push(entry.id);
     await persistCampaignState(campaignState);
@@ -101,7 +102,8 @@ export function getConnection(journalEntryId) {
     if (!entry) return null;
     const page = entry.pages?.contents?.[0];
     return page?.flags?.[MODULE_ID]?.[FLAG_KEY] ?? null;
-  } catch {
+  } catch (err) {
+    console.error(`${MODULE_ID} | getConnection(${journalEntryId}) failed:`, err);
     return null;
   }
 }

--- a/src/entities/settlement.js
+++ b/src/entities/settlement.js
@@ -90,7 +90,8 @@ export function getSettlement(journalEntryId) {
     const entry = game.journal?.get(journalEntryId);
     const page  = entry?.pages?.contents?.[0];
     return page?.flags?.[MODULE_ID]?.[FLAG_KEY] ?? null;
-  } catch {
+  } catch (err) {
+    console.error(`${MODULE_ID} | getSettlement(${journalEntryId}) failed:`, err);
     return null;
   }
 }

--- a/src/integration/quench.js
+++ b/src/integration/quench.js
@@ -483,26 +483,45 @@ function registerSectorCreatorTests(quench) {
       const { describe, it, assert, after } = context;
 
       describe("storeSector — live journal", function () {
-        let createdSectorId = null;
+        let createdSectorId     = null;
+        let createdSettlementIds = [];
+        let createdConnectionId  = null;
 
         after(async function () {
-          // Clean up: remove sector from campaignState
+          // Clean up: remove sector and entity IDs from campaignState
           const state = game.settings.get("starforged-companion", "campaignState");
           if (createdSectorId) {
             state.sectors = (state.sectors ?? []).filter(s => s.id !== createdSectorId);
             if (state.activeSectorId === createdSectorId) state.activeSectorId = null;
+          }
+          if (createdSettlementIds.length) {
+            state.settlementIds = (state.settlementIds ?? [])
+              .filter(id => !createdSettlementIds.includes(id));
+          }
+          if (createdConnectionId) {
+            state.connectionIds = (state.connectionIds ?? [])
+              .filter(id => id !== createdConnectionId);
+          }
+          if (createdSectorId || createdSettlementIds.length || createdConnectionId) {
             await game.settings.set("starforged-companion", "campaignState", state);
           }
         });
 
         it("creates a 'Starforged Sectors' journal if none exists", async function () {
-          const { generateSector, storeSector } = await import(
+          const { generateSector, storeSector, createEntityJournals } = await import(
             `${MODULE_PATH}/sectors/sectorGenerator.js`
           );
           const state  = game.settings.get("starforged-companion", "campaignState");
           const sector = generateSector("expanse");
           createdSectorId = sector.id;
-          await storeSector(sector, state);
+          const entityData = await createEntityJournals(sector, state);
+          createdSettlementIds = Object.values(entityData.settlements)
+            .filter(Boolean).map(j => j.id);
+          createdConnectionId = entityData.connectionJournalId ?? null;
+          await storeSector(sector, {
+            settlements:         entityData.settlements,
+            connectionJournalId: entityData.connectionJournalId,
+          }, state);
           const journal = game.journal.getName("Starforged Sectors");
           assert.isNotNull(journal, "Starforged Sectors journal should exist");
         });

--- a/src/sectors/sceneBuilder.js
+++ b/src/sectors/sceneBuilder.js
@@ -43,9 +43,16 @@ const SCENE_CONFIG = {
 export async function createSectorScene(sector, backgroundPath, entityJournals) {
   const { sceneWidth, sceneHeight, gridCellSize, padding } = SCENE_CONFIG;
 
+  // Foundry v13 scene img requires a path from the server root.
+  // FilePicker.upload returns a relative path (no leading slash); add one.
+  const imgPath = backgroundPath
+    ? (backgroundPath.startsWith("/") ? backgroundPath : `/${backgroundPath}`)
+    : null;
+  console.log(`${MODULE_ID} | createSectorScene: backgroundPath = ${backgroundPath}, imgPath = ${imgPath}`);
+
   const scene = await Scene.create({
     name:            sector.name,
-    img:             backgroundPath ?? null,
+    img:             imgPath,
     width:           sceneWidth,
     height:          sceneHeight,
     backgroundColor: "#000000",
@@ -140,7 +147,7 @@ export async function createSectorScene(sector, backgroundPath, entityJournals) 
 // HELPERS
 // ─────────────────────────────────────────────────────────────────────────────
 
-function makePassageLine(x1, y1, x2, y2, passage, dashed) {
+function makePassageLine(x1, y1, x2, y2, passage, _dashed) {
   return {
     x:           x1,
     y:           y1,
@@ -150,9 +157,9 @@ function makePassageLine(x1, y1, x2, y2, passage, dashed) {
       height: 0,
       points: [0, 0, x2 - x1, y2 - y1],
     },
-    strokeWidth: dashed ? 2 : 3,
-    strokeColor: "#4477aa",
-    strokeAlpha: dashed ? 0.5 : 0.8,
+    strokeWidth: 2,
+    strokeColor: "#7EB8F7",
+    strokeAlpha: 0.8,
     fillType:    0,   // no fill — important for line drawings
     hidden:      false,
     flags: {

--- a/src/sectors/sectorArt.js
+++ b/src/sectors/sectorArt.js
@@ -162,9 +162,9 @@ async function uploadSectorImage(b64, sectorId) {
   const filename = `sector-${sectorId}.png`;
 
   // Ensure the upload directory exists before uploading.
-  // FilePicker.createDirectory() throws if the directory already exists — ignore that error.
+  // createDirectory() throws if the directory already exists — ignore that error.
   try {
-    await FilePicker.createDirectory("data", UPLOAD_DIR, {});
+    await foundry.applications.apps.FilePicker.implementation.createDirectory("data", UPLOAD_DIR, {});
   } catch {
     // Directory already exists — not an error
   }
@@ -178,6 +178,6 @@ async function uploadSectorImage(b64, sectorId) {
   const blob = new Blob([bytes], { type: "image/png" });
   const file = new File([blob], filename, { type: "image/png" });
 
-  const result = await FilePicker.upload("data", UPLOAD_DIR, file, {}, { notify: false });
+  const result = await foundry.applications.apps.FilePicker.implementation.upload("data", UPLOAD_DIR, file, {}, { notify: false });
   return result?.path ?? null;
 }


### PR DESCRIPTION
## Summary
This PR addresses Foundry v13 compatibility issues and improves test infrastructure by fixing FilePicker API usage, normalizing scene image paths, and enhancing test cleanup to properly remove all created entities.

## Key Changes

- **Foundry v13 API Migration**: Updated `FilePicker` calls to use the new `foundry.applications.apps.FilePicker.implementation` namespace for v13 compatibility
- **Scene Image Path Normalization**: Added logic to ensure scene background image paths include a leading slash as required by Foundry v13's scene `img` property
- **Enhanced Test Cleanup**: Extended the `storeSector` test's cleanup handler to properly remove created settlements and connections from campaign state, not just sectors
- **Improved Error Handling**: Added error logging to `getConnection()` and `getSettlement()` functions to aid debugging
- **Code Quality**: 
  - Marked unused `dashed` parameter as `_dashed` in `makePassageLine()`
  - Simplified passage line styling (removed conditional dashing logic)
  - Updated comment references to use correct API names
  - Improved variable alignment for readability

## Notable Implementation Details

- The test now captures settlement and connection IDs created during sector generation and properly cleans them up via the campaign state
- Scene image path handling gracefully supports both absolute paths (with leading slash) and relative paths from FilePicker uploads
- Added defensive initialization of `campaignState.connectionIds` array before use

https://claude.ai/code/session_01CoUiDs3mdrqGAaAKgnvaeW