### PR TITLE
test: freeze clock for isNewSessionStart boundary test

### DIFF
--- a/tests/unit /recap.test.js
+++ b/tests/unit /recap.test.js
@@ -73,8 +73,13 @@ describe('isNewSessionStart()', () => {
   });
 
   it('returns false when gap equals the threshold exactly', () => {
-    const state = makeCampaignState({ lastSessionTimestamp: hoursAgo(4) });
+    vi.useFakeTimers();
+    const now = Date.now();
+    const state = makeCampaignState({
+      lastSessionTimestamp: new Date(now - 4 * 3_600_000).toISOString(),
+    });
     expect(isNewSessionStart(state, 4)).toBe(false);
+    vi.useRealTimers();
   });
 
   it('respects a custom threshold', () => {


### PR DESCRIPTION
hoursAgo(4) computes a timestamp, then microseconds elapse before isNewSessionStart() calls Date.now() internally. That tiny gap pushes hoursSince to 4.000001 which evaluates > 4 as true, making the "equals threshold exactly" assertion flaky on CI.

Fix: vi.useFakeTimers() / vi.useRealTimers() around the single boundary-equality test so both the timestamp creation and the internal Date.now() call see the same frozen clock value.

https://claude.ai/code/session_01CoUiDs3mdrqGAaAKgnvaeW