### PR TITLE
Increase timeout for end-to-end interpretation test

### DIFF
--- a/src/integration/quench.js
+++ b/src/integration/quench.js
@@ -421,6 +421,7 @@ function registerPipelineTests(quench) {
 
       describe("End-to-end: interpret → resolve → assemble", function () {
         it("interpretMove returns a valid interpretation", async function () {
+          this.timeout(30000);
           const apiKey = game.settings.get("starforged-companion", "claudeApiKey");
           if (!apiKey) { this.skip(); return; }
 


### PR DESCRIPTION
## Summary
Increased the test timeout for the end-to-end interpretation test to accommodate longer execution times, particularly for API calls to Claude.

## Changes
- Added `this.timeout(30000)` to the "interpretMove returns a valid interpretation" test case to set a 30-second timeout instead of the default Mocha timeout

## Details
The test makes external API calls to Claude for move interpretation, which can take longer than the default test timeout. This change ensures the test has sufficient time to complete without timing out prematurely.

https://claude.ai/code/session_01GugYWSiTqN78fy6o18Uhkn