### PR TITLE
Improve passage drawing robustness and rendering

### DIFF
--- a/src/sectors/sceneBuilder.js
+++ b/src/sectors/sceneBuilder.js
@@ -131,7 +131,13 @@ export async function createSectorScene(sector, backgroundPath, entityJournals) 
       .filter(Boolean);
 
     if (drawingData.length) {
-      await scene.createEmbeddedDocuments("Drawing", drawingData, { render: false });
+      // Passages are visual sugar — a sector without drawn passages is better
+      // than a sector that fails to finalise. Swallow validation errors.
+      try {
+        await scene.createEmbeddedDocuments("Drawing", drawingData, { render: false });
+      } catch (err) {
+        console.warn(`${MODULE_ID} | createSectorScene: drawing creation failed:`, err.message);
+      }
     }
   }
 
@@ -161,6 +167,7 @@ function makePassageLine(x1, y1, x2, y2, passage, _dashed) {
     strokeColor: "#7EB8F7",
     strokeAlpha: 0.8,
     fillType:    0,   // no fill — important for line drawings
+    fillAlpha:   0,
     hidden:      false,
     flags: {
       [MODULE_ID]: {


### PR DESCRIPTION
## Summary
This PR improves the reliability and visual consistency of passage drawing in sector scenes by adding error handling for drawing creation and ensuring proper fill rendering.

## Key Changes
- **Error handling for drawing creation**: Wrapped the `createEmbeddedDocuments` call in a try-catch block to gracefully handle validation errors during passage drawing. Passages are treated as visual enhancements, so failures should not prevent sector finalization. Errors are logged as warnings for debugging.
- **Fixed fill rendering**: Added explicit `fillAlpha: 0` to passage line drawings to ensure lines render without fill, maintaining visual consistency and preventing unexpected rendering behavior.

## Implementation Details
- The error handling approach prioritizes sector creation success over passage visualization, as passages are considered optional visual elements
- Error messages are logged with the module ID for better debugging and traceability
- The `fillAlpha: 0` setting complements the existing `fillType: 0` (no fill) configuration to ensure consistent line rendering across different rendering contexts

https://claude.ai/code/session_01VbmJ5RepLtTHK32U3CvE9Y