### PR TITLE
Enforce pure space views in sector art generation and fix scene dimensions

### DIFF
--- a/src/sectors/sceneBuilder.js
+++ b/src/sectors/sceneBuilder.js
@@ -20,11 +20,11 @@ const MODULE_ID = "starforged-companion";
 
 const SCENE_CONFIG = {
   gridCellSize: 100,
-  gridWidth:     14,
-  gridHeight:    10,
-  get sceneWidth()  { return this.gridWidth  * this.gridCellSize; },
-  get sceneHeight() { return this.gridHeight * this.gridCellSize; },
-  padding: 0.1,
+  gridWidth:    17,    // ceil(1792 / 100) — covers full image width
+  gridHeight:   10,    // ceil(1024 / 100) — covers full image height
+  sceneWidth:   1792,
+  sceneHeight:  1024,
+  padding:      0,     // no padding — image fills the canvas edge to edge
 };
 
 

--- a/src/sectors/sectorArt.js
+++ b/src/sectors/sectorArt.js
@@ -22,41 +22,50 @@ const UPLOAD_DIR = "modules/starforged-companion/art";
 // REGION VISUAL PROFILES
 // ─────────────────────────────────────────────────────────────────────────────
 
+// Hard exclusion clause — appended to every region prompt, every trouble
+// modifier, and the base prompt template to keep DALL-E producing pure space
+// views with no planetary surfaces, terrain, or architecture.
+const PURE_SPACE_EXCLUSION =
+  "Pure deep space view only. No planets in foreground, no ground, no " +
+  "landscapes, no cityscapes, no architecture, no terrain, no horizon " +
+  "lines. Stars, nebulae, gas clouds, and distant celestial objects only.";
+
 const REGION_PROMPTS = {
   terminus: "Dense star field, warm amber and gold hues, colorful nebulae in the background, " +
     "distant station and settlement lights visible, active space lanes, inhabited and settled " +
     "feeling, cinematic science fiction space art, 1792x1024 wide landscape orientation, " +
-    "no text or labels",
+    "no text or labels. " + PURE_SPACE_EXCLUSION,
 
   outlands: "Sparse star field, cool blue and white tones, one or two distant nebulae, " +
     "scattered isolated settlement lights, frontier space feeling, recent expansion into the " +
     "unknown, cinematic science fiction space art, 1792x1024 wide landscape orientation, " +
-    "no text or labels",
+    "no text or labels. " + PURE_SPACE_EXCLUSION,
 
   expanse:  "Very sparse star field, deep cold blues and blacks, vast emptiness, a single " +
     "distant galaxy smear or lone nebula as the only color, almost no settlement lights, " +
     "desolate and beautiful, pioneer space at the edge of the known, cinematic science " +
-    "fiction space art, 1792x1024 wide landscape orientation, no text or labels",
+    "fiction space art, 1792x1024 wide landscape orientation, no text or labels. " +
+    PURE_SPACE_EXCLUSION,
 
   void:     "Near-total darkness, isolated stars barely visible, vast empty void, no " +
     "settlements, hostile and forbidding, the space beyond the Forge where travel is " +
     "impossible, cinematic science fiction space art, 1792x1024 wide landscape orientation, " +
-    "no text or labels",
+    "no text or labels. " + PURE_SPACE_EXCLUSION,
 };
 
 const TROUBLE_VISUAL_MODIFIERS = {
   "Energy storms are rampant":
-    "with visible crackling energy storms and lightning",
+    "with visible crackling energy storms and lightning. " + PURE_SPACE_EXCLUSION,
   "Magnetic disturbances disrupt communication":
-    "with aurora-like magnetic disturbances visible",
+    "with aurora-like magnetic disturbances visible. " + PURE_SPACE_EXCLUSION,
   "Supernova is imminent":
-    "with a bright dying star dominating the background",
+    "with a bright dying star dominating the background. " + PURE_SPACE_EXCLUSION,
   "Chaotic breaches in spacetime spread like wildfire":
-    "with strange spatial distortions and rifts visible",
+    "with strange spatial distortions and rifts visible. " + PURE_SPACE_EXCLUSION,
   "Dense nebula cloud":
-    "with a vast colorful nebula filling the background",
+    "with a vast colorful nebula filling the background. " + PURE_SPACE_EXCLUSION,
   "Fiery energy storm":
-    "with billowing plasma storms and solar flares",
+    "with billowing plasma storms and solar flares. " + PURE_SPACE_EXCLUSION,
 };
 
 
@@ -122,7 +131,15 @@ export function buildSectorBackgroundPrompt(sector) {
   const base    = REGION_PROMPTS[region] ?? REGION_PROMPTS.outlands;
 
   const modifier = TROUBLE_VISUAL_MODIFIERS[sector.trouble] ?? null;
-  const prompt   = modifier ? `${base}, ${modifier}` : base;
+  const body     = modifier ? `${base}, ${modifier}` : base;
+
+  // Append the exclusion clause once more at the template level so the
+  // restriction still applies if region or modifier strings change later.
+  const prompt = `${body} Wide cinematic space panorama, 1792x1024 landscape ` +
+    `orientation, no text or labels. Pure deep space view only — no planets ` +
+    `in foreground, no ground, no landscapes, no cityscapes, no architecture, ` +
+    `no terrain, no horizon lines. Stars, nebulae, gas clouds, and distant ` +
+    `celestial objects only.`;
 
   return { prompt, size: "1792x1024" };
 }


### PR DESCRIPTION
## Summary
This PR improves the consistency and quality of AI-generated sector artwork by enforcing strict exclusion criteria to prevent planetary surfaces and terrain, while also correcting scene canvas dimensions to properly match the generated image size.

## Key Changes

- **Added `PURE_SPACE_EXCLUSION` constant** in `sectorArt.js` that defines a hard exclusion clause preventing DALL-E from generating planets, terrain, architecture, or horizons. This clause is now appended to:
  - All region prompts (terminus, outlands, expanse, void)
  - All trouble visual modifiers
  - The final prompt template (applied three times total for reinforcement)

- **Enhanced `buildSectorBackgroundPrompt()`** to append the exclusion clause at the template level, ensuring the restriction persists even if region or modifier strings change in the future

- **Fixed scene canvas dimensions** in `sceneBuilder.js`:
  - Updated `gridWidth` from 14 to 17 cells (ceil(1792 / 100))
  - Updated `gridHeight` from 10 to 10 cells (ceil(1024 / 100))
  - Changed `sceneWidth` and `sceneHeight` from computed getters to fixed values (1792 × 1024)
  - Set `padding` to 0 to ensure generated images fill the canvas edge-to-edge without gaps

## Implementation Details

The exclusion clause is applied redundantly at multiple levels (region, modifier, and template) to maximize the likelihood that DALL-E respects the constraint despite potential prompt variations. The scene dimensions now precisely match the 1792×1024 landscape orientation specified in the art generation prompts, eliminating any scaling or positioning issues.

https://claude.ai/code/session_016587MKKc2EDwCEJAJGqz9j