### PR TITLE
Update for Foundry v13 scene and note API changes

### DIFF
--- a/docs/foundry-api-reference.md
+++ b/docs/foundry-api-reference.md
@@ -608,7 +608,7 @@ async function postCard(content, flags = {}) {
 ```js
 const scene = await Scene.create({
   name:            "Devil's Maw",
-  img:             "modules/starforged-companion/art/sector-abc123.png",  // path, not base64
+  background:      { src: "modules/starforged-companion/art/sector-abc123.png" },  // v13: background.src not img
   width:           1400,   // scene pixel width — should match image dimensions
   height:          1000,   // scene pixel height
   backgroundColor: "#000000",
@@ -691,10 +691,12 @@ await scene.createEmbeddedDocuments("Note", [
     x:          500,               // canvas pixel x position
     y:          300,               // canvas pixel y position
 
-    // Icon
-    icon:       "icons/svg/circle.svg",   // path to icon image
-    iconSize:   40,                        // icon size in pixels (default 40)
-    iconTint:   "#ffffff",                 // CSS color or null for no tint
+    // Icon — v13: moved to texture object
+    texture: {
+      src:  "icons/svg/circle.svg",   // path to icon image
+      tint: "#ffffff",                // CSS color or null for no tint
+    },
+    iconSize:   40,                   // icon size in pixels (default 40)
 
     // Label text shown below/above the pin
     text:       "Bleakhold Station",
@@ -891,7 +893,7 @@ const path = await uploadBase64Image(
 - `source: "data"` uploads to the Foundry user data folder — correct for module assets
 - `source: "public"` uploads to the public folder — not needed for module assets
 - `FilePicker.createDirectory()` throws if the directory already exists — always wrap in try/catch
-- The returned `result.path` is what goes into `scene.img` or `actor.img`
+- The returned `result.path` is what goes into `scene.background.src` or `actor.img`
 - **Requires GM permissions** — only call from contexts where `game.user.isGM` is true
 - The upload is a server-side operation; the Electron renderer makes an HTTP POST to
   the local Foundry server (not an external API — no proxy needed)

--- a/src/sectors/sceneBuilder.js
+++ b/src/sectors/sceneBuilder.js
@@ -43,7 +43,7 @@ const SCENE_CONFIG = {
 export async function createSectorScene(sector, backgroundPath, entityJournals) {
   const { sceneWidth, sceneHeight, gridCellSize, padding } = SCENE_CONFIG;
 
-  // Foundry v13 scene img requires a path from the server root.
+  // Foundry v13 scene background.src requires a path from the server root.
   // FilePicker.upload returns a relative path (no leading slash); add one.
   const imgPath = backgroundPath
     ? (backgroundPath.startsWith("/") ? backgroundPath : `/${backgroundPath}`)
@@ -52,7 +52,7 @@ export async function createSectorScene(sector, backgroundPath, entityJournals) 
 
   const scene = await Scene.create({
     name:            sector.name,
-    img:             imgPath,
+    background:      { src: imgPath },
     width:           sceneWidth,
     height:          sceneHeight,
     backgroundColor: "#000000",
@@ -84,9 +84,11 @@ export async function createSectorScene(sector, backgroundPath, entityJournals) 
         entryId:    journal?.id ?? null,
         x:          s.gridX * gridCellSize,
         y:          s.gridY * gridCellSize,
-        icon:       iconPathForLocationType(locationType),
+        texture: {
+          src:  iconPathForLocationType(locationType),
+          tint: tintForLocationType(locationType),
+        },
         iconSize:   40,
-        iconTint:   tintForLocationType(locationType),
         text:       s.name,
         fontSize:   24,
         textColor:  "#FFFFFF",

--- a/src/sectors/sectorArt.js
+++ b/src/sectors/sectorArt.js
@@ -129,6 +129,14 @@ export function buildSectorBackgroundPrompt(sector) {
     `the void with nothing in the foreground, middleground, or near field. No ` +
     `celestial bodies closer than a distant star. No planets, moons, asteroids, ` +
     `ships, structures, ground, terrain, or atmosphere visible at any scale. ` +
+    `The image shows only the interstellar medium — the space between star ` +
+    `systems. There is no nearby object of any kind. No planet, moon, asteroid, ` +
+    `comet, debris field, ship, station, or structure exists at any distance ` +
+    `that would be visible to the naked eye or any instrument. The only visible ` +
+    `objects are stars (as points of light), nebulae (as diffuse gas clouds), ` +
+    `and distant galaxies (as smears of light). Nothing has a disc, surface, ` +
+    `atmosphere, rings, or any resolved shape. Every light source is a point ` +
+    `or a diffuse cloud. ` +
     `Wide cinematic panorama, 1792x1024 landscape orientation, no text, no labels, no borders.`;
 
   return { prompt, size: "1792x1024" };


### PR DESCRIPTION
## Summary
Updates the codebase to be compatible with Foundry v13's API changes for scene backgrounds and note textures. The changes migrate from deprecated `img` and `icon`/`iconTint` properties to the new `background.src` and `texture` object structures.

## Key Changes
- **Scene backgrounds**: Changed `scene.img` to `scene.background.src` in scene creation
- **Note icons**: Migrated from separate `icon`, `iconSize`, and `iconTint` properties to a consolidated `texture` object with `src` and `tint` properties, keeping `iconSize` as a sibling property
- **Documentation updates**: Updated API reference examples and comments to reflect v13 changes
- **Prompt refinement**: Enhanced sector background art prompt with more detailed constraints to prevent unwanted objects in generated images

## Implementation Details
- The `texture` object structure for notes groups icon source and tint together, improving API consistency
- File path handling remains unchanged; paths are still relative from server root
- All changes are backward-incompatible with pre-v13 Foundry versions
- Updated comments clarify the v13 API structure for future maintainers

https://claude.ai/code/session_0115WjvL8tdngF1w7pve8pNB