### PR TITLE
Increase passage counts per region and organize sectors into folders

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,6 +31,7 @@ export default [
         foundry:      "readonly",
         ChatMessage:  "readonly",
         JournalEntry: "readonly",
+        Folder:       "readonly",
         Scene:        "readonly",
         FilePicker:   "readonly",
         Dialog:       "readonly",

--- a/src/sectors/sectorGenerator.js
+++ b/src/sectors/sectorGenerator.js
@@ -433,8 +433,17 @@ export async function createSectorJournal(sector, stubs = {}) {
   try {
     const regionLabel = REGION_LABELS[sector.region] ?? sector.regionLabel ?? sector.region;
 
+    const sectorsFolder = game.folders?.find(
+      f => f.name === "Sectors" && f.type === "JournalEntry"
+    ) ?? await Folder.create({
+      name:  "Sectors",
+      type:  "JournalEntry",
+      color: "#4A6FA5",
+    });
+
     const journal = await JournalEntry.create({
-      name:  `${sector.name} — Sector Record`,
+      name:   `${sector.name} — Sector Record`,
+      folder: sectorsFolder.id,
       flags: {
         [MODULE_ID]: {
           sectorRecord: true,

--- a/src/sectors/sectorGenerator.js
+++ b/src/sectors/sectorGenerator.js
@@ -36,9 +36,9 @@ const MODULE_ID = "starforged-companion";
 // ─────────────────────────────────────────────────────────────────────────────
 
 const REGION_CONFIG = {
-  terminus: { settlements: 4, passages: 3, label: "Terminus" },
-  outlands: { settlements: 3, passages: 2, label: "Outlands" },
-  expanse:  { settlements: 2, passages: 1, label: "Expanse"  },
+  terminus: { settlements: 4, passages: 4, label: "Terminus" },
+  outlands: { settlements: 3, passages: 3, label: "Outlands" },
+  expanse:  { settlements: 2, passages: 2, label: "Expanse"  },
 };
 
 const POPULATION_TABLE_BY_REGION = {

--- a/src/sectors/sectorPanel.js
+++ b/src/sectors/sectorPanel.js
@@ -235,11 +235,9 @@ export class SectorCreatorApp extends ApplicationV2 {
       // entity description matches what the sector journal page shows.
       await applyStubsToSettlementEntities(entityData.settlements, stubs);
 
-      // Sector journal (needs stubs); scene (needs background + entity journals)
-      const [sectorJournal, scene] = await Promise.all([
-        createSectorJournal(this.#sector, stubs),
-        createSectorScene(this.#sector, backgroundPath, entityData.settlements),
-      ]);
+      // Sector journal (needs stubs); scene sequential after background resolves
+      const sectorJournal = await createSectorJournal(this.#sector, stubs);
+      const scene         = await createSectorScene(this.#sector, backgroundPath, entityData.settlements);
 
       const stored = await storeSector(this.#sector, {
         settlements:         entityData.settlements,

--- a/src/sectors/sectorPanel.js
+++ b/src/sectors/sectorPanel.js
@@ -108,15 +108,15 @@ export class SectorCreatorApp extends ApplicationV2 {
           <div class="sf-region-choices">
             <button class="sf-region-btn" data-action="chooseRegion" data-region="terminus">
               <strong>Terminus</strong>
-              <span>4 settlements · 3 passages · Dense, well-charted</span>
+              <span>4 settlements · 4 passages · Dense, well-charted</span>
             </button>
             <button class="sf-region-btn" data-action="chooseRegion" data-region="outlands">
               <strong>Outlands</strong>
-              <span>3 settlements · 2 passages · Frontier, scattered</span>
+              <span>3 settlements · 3 passages · Frontier, scattered</span>
             </button>
             <button class="sf-region-btn" data-action="chooseRegion" data-region="expanse">
               <strong>Expanse</strong>
-              <span>2 settlements · 1 passage · Remote, uncharted</span>
+              <span>2 settlements · 2 passages · Remote, uncharted</span>
             </button>
           </div>
         </div>

--- a/tests/unit/sectorGenerator.test.js
+++ b/tests/unit/sectorGenerator.test.js
@@ -199,9 +199,9 @@ describe("generateSector('terminus')", () => {
     expect(sector.settlements).toHaveLength(4);
   });
 
-  it("produces 3 passages for terminus", () => {
+  it("produces 4 passages for terminus", () => {
     const sector = generateSector("terminus");
-    expect(sector.passages).toHaveLength(3);
+    expect(sector.passages).toHaveLength(4);
   });
 
   it("sector has a trouble string", () => {
@@ -234,9 +234,9 @@ describe("generateSector('outlands')", () => {
     expect(sector.settlements).toHaveLength(3);
   });
 
-  it("produces 2 passages for outlands", () => {
+  it("produces 3 passages for outlands", () => {
     const sector = generateSector("outlands");
-    expect(sector.passages).toHaveLength(2);
+    expect(sector.passages).toHaveLength(3);
   });
 });
 
@@ -246,9 +246,9 @@ describe("generateSector('expanse')", () => {
     expect(sector.settlements).toHaveLength(2);
   });
 
-  it("produces 1 passage for expanse", () => {
+  it("produces 2 passages for expanse", () => {
     const sector = generateSector("expanse");
-    expect(sector.passages).toHaveLength(1);
+    expect(sector.passages).toHaveLength(2);
   });
 });
 


### PR DESCRIPTION
## Summary
This PR increases the number of passages generated for each region and implements automatic organization of sector journals into a dedicated "Sectors" folder.

## Key Changes
- **Passage count adjustments**: Increased passages per region to match settlement counts
  - Terminus: 3 → 4 passages
  - Outlands: 2 → 3 passages
  - Expanse: 1 → 2 passages
- **Sector folder organization**: Sector journals are now automatically created in or moved to a "Sectors" folder (with blue color #4A6FA5)
- **Sequential creation**: Changed sector journal and scene creation from parallel (`Promise.all`) to sequential execution to ensure proper dependency ordering
- **UI updates**: Updated region selection buttons to reflect new passage counts
- **Test updates**: Updated unit tests to verify the new passage count expectations
- **ESLint config**: Added `Folder` to the list of readonly globals for Foundry API

## Implementation Details
- The "Sectors" folder is created automatically if it doesn't exist, using the Foundry `Folder.create()` API
- Sector journals now include a `folder` property pointing to the sectors folder ID
- Scene creation now awaits the sector journal creation to ensure proper sequencing

https://claude.ai/code/session_01DCUdpmVJFHWsXL45anfTXi