### PR TITLE
Refactor world truths handling and improve journal detection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -944,6 +944,22 @@ Hooks.once("ready", () => {
           console.warn(`${MODULE_ID} | truths setup card failed:`, err)
         );
       }
+
+      // Fallback — link the system's truths journal if truths were set before
+      // the createJournalEntryPage hook was wired, or if the ID was never stored.
+      if (!freshState.worldTruthsJournalId) {
+        const systemTitle = game.i18n?.localize?.("IRONSWORN.JOURNALENTRYPAGES.TypeTruth") ?? "";
+        if (systemTitle) {
+          const truthsJournal = game.journal?.contents?.find(j => j.name === systemTitle);
+          if (truthsJournal) {
+            freshState.worldTruthsJournalId = truthsJournal.id;
+            freshState.worldTruthsSet       = true;
+            game.settings.set(MODULE_ID, "campaignState", freshState).catch(err =>
+              console.warn(`${MODULE_ID} | ready: fallback truths link failed:`, err)
+            );
+          }
+        }
+      }
     }).catch(err => {
       console.error(`${MODULE_ID} | Failed to persist session ID:`, err);
     });
@@ -1122,31 +1138,29 @@ Hooks.on("renderChatMessage", (message, html) => {
 });
 
 /**
- * createJournalEntry — detect when the system's World Truths dialog saves truths.
+ * createJournalEntryPage — detect when the system's World Truths dialog saves truths.
  *
- * The system's saveTruths() creates a JournalEntry named with the i18n key
- * IRONSWORN.JOURNALENTRYPAGES.TypeTruth ("Setting Truths" in English) with a
- * single plain-text page of the same name, no module flags on either document,
- * and content consisting of <h2>-headed truth category sections.
+ * saveTruths() in sf-truths.vue creates the JournalEntry first, then the page in a
+ * separate call. The createJournalEntry hook fires before the page exists (pages.size
+ * is 0 at that point), so we listen on createJournalEntryPage instead — the parent
+ * journal is accessible as page.parent and is fully constructed.
  *
- * We use the combination of:
- *   - journal name matches the i18n key (locale-correct)
- *   - page has type "text" and no starforged-companion flags
- *   - content contains ≥2 <h2> elements (rules out accidental name collisions)
+ * The system journal name matches i18n key IRONSWORN.JOURNALENTRYPAGES.TypeTruth
+ * ("Setting Truths" in English). No module flags are written on either document.
+ * Content has ≥2 <h2> elements — one per truth category saved.
  */
-Hooks.on("createJournalEntry", async (entry) => {
+Hooks.on("createJournalEntryPage", async (page) => {
   if (!game.user.isGM) return;
 
-  // Must have exactly one page — system truths dialog creates exactly one
-  if (!entry.pages?.size || entry.pages.size !== 1) return;
-  const page = entry.pages.contents[0];
+  const entry = page.parent;
+  if (!entry) return;
 
-  // Page must be a plain text page with no flags from our module
+  // Page must be plain text with no flags from our module
   if (page.type !== "text") return;
   if (page.flags?.[MODULE_ID]) return;
   if (entry.flags?.[MODULE_ID]) return;
 
-  // Name must match the system's i18n key (locale-safe at runtime)
+  // Journal name must match the system's i18n key (locale-safe at runtime)
   const systemTitle = game.i18n?.localize?.("IRONSWORN.JOURNALENTRYPAGES.TypeTruth") ?? "";
   if (!systemTitle || entry.name !== systemTitle) return;
 
@@ -1160,7 +1174,7 @@ Hooks.on("createJournalEntry", async (entry) => {
   campaignState.worldTruthsSet       = true;
   campaignState.worldTruthsJournalId = entry.id;
   await game.settings.set(MODULE_ID, "campaignState", campaignState).catch(err =>
-    console.error(`${MODULE_ID} | createJournalEntry: failed to persist truths state:`, err)
+    console.error(`${MODULE_ID} | createJournalEntryPage: failed to persist truths state:`, err)
   );
 
   // Dismiss the setup notification card if it is still in chat

--- a/src/truths/generator.js
+++ b/src/truths/generator.js
@@ -346,39 +346,17 @@ export async function generateLoreRecap(campaignState) {
     return null;
   }
 
-  // Build source text — prefer structured truths, fall back to system journal HTML
-  let truthsText = "";
-  const truthSet = campaignState.worldTruths;
-  if (truthSet && Object.keys(truthSet).length) {
-    truthsText = formatForContext(truthSet);
-  } else if (campaignState.worldTruthsJournalId) {
-    try {
-      const je   = game.journal?.get(campaignState.worldTruthsJournalId);
-      const page = je?.pages?.contents?.[0];
-      const html = page?.text?.content ?? "";
-      truthsText = html.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim().slice(0, 2000);
-    } catch (err) {
-      console.warn(`${MODULE_ID} | lore: could not read truths journal:`, err);
-    }
-  }
-
-  if (!truthsText) {
-    ui?.notifications?.warn(
-      "Starforged Companion: No world truths established yet. Use !truths first."
-    );
-    return null;
-  }
-
   let recap = null;
   try {
-    recap = await callLoreRecapNarrator(truthsText, apiKey);
+    recap = await callLoreRecapNarrator(campaignState, apiKey);
   } catch (err) {
     console.error(`${MODULE_ID} | lore: callLoreRecapNarrator failed:`, err);
     ui?.notifications?.error("Starforged Companion: !lore failed — check console and API key.");
     return null;
   }
 
-  if (!recap?.trim()) return null;
+  if (!recap) return null;
+  if (!recap.trim()) return null;
 
   campaignState.loreRecap          = recap;
   campaignState.loreRecapSessionId = campaignState.currentSessionId ?? null;
@@ -407,7 +385,39 @@ export async function generateLoreRecap(campaignState) {
   return recap;
 }
 
-async function callLoreRecapNarrator(truthsText, apiKey) {
+async function callLoreRecapNarrator(campaignState, apiKey) {
+  let truthsContent = "";
+
+  // Try system journal first — it's the authoritative source when set via dialog
+  if (campaignState.worldTruthsJournalId) {
+    const entry = game.journal?.get(campaignState.worldTruthsJournalId);
+    const page  = entry?.pages?.contents?.[0];
+    const html  = page?.text?.content ?? "";
+    if (html.trim()) {
+      truthsContent = html
+        .replace(/<[^>]+>/g, " ")
+        .replace(/\s+/g, " ")
+        .trim();
+    }
+  }
+
+  // Fall back to structured format — but validate it has real content
+  if (!truthsContent && campaignState.worldTruths) {
+    const formatted = formatForContext(campaignState.worldTruths);
+    if (formatted && !formatted.includes("undefined")) {
+      truthsContent = formatted;
+    }
+  }
+
+  // Guard — nothing to work with
+  if (!truthsContent) {
+    ui?.notifications?.warn(
+      "Starforged Companion: World Truths content could not be read. " +
+      "Try setting truths again with !truths."
+    );
+    return null;
+  }
+
   const systemPrompt =
     "You are a world-weary spacer narrator — sardonic, laconic, and atmospheric. " +
     "When given a list of world truths, you summarise them as a brief in-world passage: " +
@@ -418,7 +428,7 @@ async function callLoreRecapNarrator(truthsText, apiKey) {
     model:      "claude-haiku-4-5-20251001",
     max_tokens: 300,
     system:     systemPrompt,
-    messages:   [{ role: "user", content: `Summarise these world truths:\n\n${truthsText}` }],
+    messages:   [{ role: "user", content: `Summarise these world truths:\n\n${truthsContent}` }],
   };
 
   const headers = {


### PR DESCRIPTION
## Summary
This PR refactors the world truths content extraction logic and improves the reliability of detecting when the system's World Truths dialog saves truths to the journal.

## Key Changes

- **Moved truths content extraction into `callLoreRecapNarrator()`**: The logic for building source text from structured truths or system journal HTML is now encapsulated within the narrator function, reducing duplication and improving separation of concerns.

- **Switched from `createJournalEntry` to `createJournalEntryPage` hook**: The system's `saveTruths()` creates the journal entry first, then the page in a separate call. By listening on `createJournalEntryPage` instead, we can reliably access the fully-constructed parent journal and its content.

- **Improved truths content validation**: Added checks to ensure extracted content is non-empty and doesn't contain formatting artifacts (e.g., "undefined" strings from malformed structured data).

- **Added fallback truths journal linking**: In the `ready` hook, if `worldTruthsJournalId` was never stored (e.g., due to hook timing issues), the code now attempts to locate and link the system's truths journal by its localized name.

- **Enhanced error messaging**: Updated user-facing warnings to be more descriptive and actionable.

## Implementation Details

- The `callLoreRecapNarrator()` function now accepts `campaignState` instead of pre-extracted `truthsText`, allowing it to handle content extraction with proper validation.
- Journal detection prioritizes the system journal (authoritative source when set via dialog) before falling back to structured truths format.
- The fallback linking mechanism in `ready` hook ensures truths are discoverable even if the initial hook wiring missed the creation event.

https://claude.ai/code/session_01MgPGVyg4JtY7ApVcL47H3b