### PR TITLE
Support GM as player in GM-less Ironsworn campaigns

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -526,11 +526,6 @@ export function isPlayerNarration(message) {
   if (message.flags?.['foundry-ironsworn']) return false;
   if (message.speaker?.alias === 'Ironsworn') return false;
 
-  // message.author is correct for both v12 and v13.
-  // message.user was the old name — accessing it in v13 logs a deprecation warning.
-  const user = message.author ?? game.users?.get(message.user);
-  if (user?.isGM) return false;
-
   const text = message.content?.trim() ?? "";
 
   // No meaningful text content — system-generated empty or near-empty messages
@@ -551,15 +546,14 @@ export function isPlayerNarration(message) {
 
 /**
  * Determine whether a chat message is a scene interrogation query.
- * Scene queries start with "@scene" (case-insensitive), come from non-GM players,
- * and are not themselves scene response cards.
+ * Scene queries start with "@scene" (case-insensitive) and are not themselves
+ * scene response cards.
  */
 export function isSceneQuery(message) {
   const text = message.content?.trim() ?? "";
   if (!text.toLowerCase().startsWith("@scene")) return false;
   if (message.flags?.[MODULE_ID]?.sceneResponse) return false;
-  const user = message.author ?? game.users?.get(message.user);
-  return !user?.isGM;
+  return true;
 }
 
 /**

--- a/src/narration/narratorPrompt.js
+++ b/src/narration/narratorPrompt.js
@@ -233,7 +233,7 @@ const PERSPECTIVE_DESCRIPTIONS = {
 export function resolveNarrationPerspective(setting) {
   if (setting !== 'auto') return setting;
   try {
-    const playerCount = game.users.filter(u => u.active && !u.isGM).length;
+    const playerCount = game.users.filter(u => u.active).length;
     return playerCount === 1 ? 'second_person' : 'third_person';
   } catch {
     return 'second_person';

--- a/tests/unit/isPlayerNarration.test.js
+++ b/tests/unit/isPlayerNarration.test.js
@@ -41,9 +41,9 @@ beforeEach(() => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('isPlayerNarration()', () => {
-  it('returns false for GM messages', () => {
+  it('returns true for GM messages — GM is a player in GM-less Ironsworn', () => {
     const msg = makeMessage({ author: { isGM: true } });
-    expect(isPlayerNarration(msg)).toBe(false);
+    expect(isPlayerNarration(msg)).toBe(true);
   });
 
   it('returns false for OOC messages (type "ooc")', () => {
@@ -123,12 +123,12 @@ describe('isSceneQuery()', () => {
     expect(isSceneQuery(msg)).toBe(true);
   });
 
-  it('returns false for "@scene" from GM', () => {
+  it('returns true for "@scene" from GM — GM is a player', () => {
     const msg = makeMessage({
       content: '@scene what do I see?',
       author:  { isGM: true },
     });
-    expect(isSceneQuery(msg)).toBe(false);
+    expect(isSceneQuery(msg)).toBe(true);
   });
 
   it('returns false for messages without @scene prefix', () => {

--- a/tests/unit/narratorPrompt.test.js
+++ b/tests/unit/narratorPrompt.test.js
@@ -183,16 +183,15 @@ describe('buildNarratorSystemPrompt()', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('resolveNarrationPerspective()', () => {
-  it('returns "second_person" for "auto" with 1 active non-GM user', () => {
-    mockUsers = [{ active: true, isGM: false }];
+  it('returns "second_person" for "auto" with 1 active user (even if GM)', () => {
+    mockUsers = [{ active: true, isGM: true }];
     expect(resolveNarrationPerspective('auto')).toBe('second_person');
   });
 
-  it('returns "third_person" for "auto" with 2+ active non-GM users', () => {
+  it('returns "third_person" for "auto" with 2+ active users (GM counts)', () => {
     mockUsers = [
       { active: true, isGM: false },
-      { active: true, isGM: false },
-      { active: true, isGM: true }, // GM ignored
+      { active: true, isGM: true },
     ];
     expect(resolveNarrationPerspective('auto')).toBe('third_person');
   });

--- a/tests/unit/sceneInterrogation.test.js
+++ b/tests/unit/sceneInterrogation.test.js
@@ -58,12 +58,12 @@ describe('isSceneQuery()', () => {
     expect(isSceneQuery(msg)).toBe(false);
   });
 
-  it('returns false for GM messages', () => {
+  it('returns true for GM @scene messages', () => {
     const msg = makeMessage({
       content: '@scene what lurks here?',
       author:  { isGM: true },
     });
-    expect(isSceneQuery(msg)).toBe(false);
+    expect(isSceneQuery(msg)).toBe(true);
   });
 
   it('returns false for "@" messages that are not "@scene"', () => {


### PR DESCRIPTION
## Summary
Updates the narration system to treat GMs as players in GM-less Ironsworn campaigns, removing GM-specific filtering from player narration and scene query detection.

## Key Changes
- **isPlayerNarration()**: Removed GM check that was filtering out GM messages. GMs are now treated as regular players for narration purposes.
- **isSceneQuery()**: Removed GM filtering. Scene queries from GMs are now accepted as valid player input.
- **resolveNarrationPerspective()**: Changed player count calculation to include active GMs. This affects automatic perspective selection (second person for 1 player, third person for 2+).

## Implementation Details
- Removed the user lookup logic (`message.author ?? game.users?.get(message.user)`) from both `isPlayerNarration()` and `isSceneQuery()` functions, simplifying the code.
- Updated JSDoc for `isSceneQuery()` to reflect that it no longer filters by GM status.
- Updated all related unit tests to expect GMs to be treated as players in these contexts.

This change aligns with the GM-less nature of Ironsworn where the GM is a participant rather than a separate authority figure.

https://claude.ai/code/session_0176WijQNTdCy8GTE9bTPPzB