### PR TITLE
Fix World Truths journal ID capture during async timing gaps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1164,6 +1164,36 @@ Hooks.on("renderChatMessage", (message, html) => {
 });
 
 /**
+ * createJournalEntry — capture worldTruthsJournalId the moment the system's
+ * "Setting Truths" journal is created, before the page and its content exist.
+ *
+ * saveTruths() in sf-truths.vue creates the JournalEntry first and the page
+ * in a separate async call. When the page content ends up empty (async timing
+ * gap in the TruthCategory.randomize() chain), the createJournalEntryPage hook
+ * below correctly rejects the empty page via its <h2> guard, leaving
+ * worldTruthsJournalId unset. This hook closes that gap by capturing the ID
+ * at journal creation time regardless of future page content.
+ *
+ * worldTruthsSet remains controlled by createJournalEntryPage and still
+ * requires ≥2 <h2> elements.
+ */
+Hooks.on("createJournalEntry", async (entry) => {
+  if (!game.user.isGM) return;
+  if (entry.flags?.[MODULE_ID]) return;
+
+  const systemTitle = game.i18n?.localize?.("IRONSWORN.JOURNALENTRYPAGES.TypeTruth") ?? "";
+  if (!systemTitle || entry.name !== systemTitle) return;
+
+  const campaignState = game.settings.get(MODULE_ID, "campaignState");
+  if (campaignState.worldTruthsSet) return; // Already recorded with real content
+
+  campaignState.worldTruthsJournalId = entry.id;
+  await game.settings.set(MODULE_ID, "campaignState", campaignState).catch(err =>
+    console.error(`${MODULE_ID} | createJournalEntry: failed to persist journal id:`, err)
+  );
+});
+
+/**
  * createJournalEntryPage — detect when the system's World Truths dialog saves truths.
  *
  * saveTruths() in sf-truths.vue creates the JournalEntry first, then the page in a

--- a/src/truths/generator.js
+++ b/src/truths/generator.js
@@ -398,6 +398,15 @@ async function callLoreRecapNarrator(campaignState, apiKey) {
         .replace(/<[^>]+>/g, " ")
         .replace(/\s+/g, " ")
         .trim();
+    } else if (entry && page) {
+      // Journal page exists but was saved with no truth selections recorded
+      // (async timing gap in TruthCategory.randomize() — model.valid stayed false)
+      ui?.notifications?.warn(
+        "Starforged Companion: World Truths dialog was saved but no truth " +
+        "selections were recorded. Re-open !truths, select or randomize each " +
+        "category, then click Save Your Truths."
+      );
+      return null;
     }
   }
 


### PR DESCRIPTION
## Summary
This PR addresses a race condition where the World Truths journal entry ID was not being captured when the journal page was created with empty content due to async timing gaps in the truth randomization process.

## Key Changes
- **New `createJournalEntry` hook** in `src/index.js`: Captures the `worldTruthsJournalId` at the moment the journal entry is created, before the page content is populated. This ensures the ID is recorded even if the subsequent page creation fails or contains no content.
  - Only runs for GM users and the system's "Setting Truths" journal
  - Respects existing `worldTruthsSet` flag to avoid overwriting entries with real content
  - Includes error handling for persistence failures

- **Enhanced error handling** in `src/truths/generator.js`: Added a warning notification when a journal page exists but was saved with no truth selections recorded, guiding users to re-open the dialog and properly select/randomize categories before saving.

## Implementation Details
- The new hook closes a timing gap where `saveTruths()` in sf-truths.vue creates the JournalEntry and page in separate async calls
- The existing `createJournalEntryPage` hook still validates page content (requires ≥2 `<h2>` elements) and controls the `worldTruthsSet` flag
- This two-layer approach ensures the journal ID is always captured while maintaining content validation

https://claude.ai/code/session_01UGGe7FwhjTjLZBEfo3yMYd