### PR TITLE
Make action handlers return promises for test integration

### DIFF
--- a/src/character/chroniclePanel.js
+++ b/src/character/chroniclePanel.js
@@ -126,37 +126,56 @@ export class ChroniclePanelApp extends foundry.applications.api.ApplicationV2 {
   }
 
   // ── Static action handlers (click via data-action) ─────────────────────────
+  //
+  // Each handler records its in-flight promise on `this._lastAction` so that
+  // integration tests can await the full async chain after dispatching a real
+  // DOM click event. ApplicationV2's action dispatcher invokes handlers
+  // fire-and-forget, so without this hook there is no way for a test to wait
+  // for multi-step persistence (journal create → page create → setFlag) to
+  // settle before re-reading state.
 
-  static async #onAddAnnotation(_event, _target) {
-    const sessionId = game.settings?.get(MODULE_ID, 'campaignState')?.currentSessionId ?? '';
-    await addChronicleEntry(this.#actorId, {
-      type:      'annotation',
-      text:      'New annotation — click to edit.',
-      sessionId,
-      automated: false,
-    });
-    this.render();
+  static #onAddAnnotation(_event, _target) {
+    const work = (async () => {
+      const sessionId = game.settings?.get(MODULE_ID, 'campaignState')?.currentSessionId ?? '';
+      await addChronicleEntry(this.#actorId, {
+        type:      'annotation',
+        text:      'New annotation — click to edit.',
+        sessionId,
+        automated: false,
+      });
+      this.render();
+    })();
+    this._lastAction = work;
+    return work;
   }
 
-  static async #onDeleteEntry(_event, target) {
-    if (!game.user?.isGM) return;
-    const entryId = target.dataset.entryId;
-    if (!entryId) return;
+  static #onDeleteEntry(_event, target) {
+    const work = (async () => {
+      if (!game.user?.isGM) return;
+      const entryId = target.dataset.entryId;
+      if (!entryId) return;
 
-    const entries = this.#entries.filter(en => en.id !== entryId);
-    await this.#saveEntries(entries);
-    this.render();
+      const entries = this.#entries.filter(en => en.id !== entryId);
+      await this.#saveEntries(entries);
+      this.render();
+    })();
+    this._lastAction = work;
+    return work;
   }
 
-  static async #onTogglePin(_event, target) {
-    const entryId = target.dataset.entryId;
-    if (!entryId) return;
+  static #onTogglePin(_event, target) {
+    const work = (async () => {
+      const entryId = target.dataset.entryId;
+      if (!entryId) return;
 
-    const updated = this.#entries.map(en =>
-      en.id === entryId ? { ...en, pinned: !en.pinned } : en
-    );
-    await this.#saveEntries(updated);
-    this.render();
+      const updated = this.#entries.map(en =>
+        en.id === entryId ? { ...en, pinned: !en.pinned } : en
+      );
+      await this.#saveEntries(updated);
+      this.render();
+    })();
+    this._lastAction = work;
+    return work;
   }
 
   // ── Persistence ───────────────────────────────────────────────────────────

--- a/src/integration/quench.js
+++ b/src/integration/quench.js
@@ -100,8 +100,17 @@ async function clickAction(app, actionName, extras = null) {
   const btn = root.querySelector(selector);
   if (!btn) throw new Error(`clickAction: no element matches ${selector}`);
   btn.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
-  // Allow the async handler to start and any awaited work to settle.
+  // Allow the async handler to start.
   await flushMicrotasks();
+  // If the handler exposes its in-flight promise on the app instance, await it.
+  // This is the only way to wait for multi-step persistence chains (e.g.
+  // JournalEntry.create → createEmbeddedDocuments → setFlag) to fully settle,
+  // because ApplicationV2's action dispatcher is fire-and-forget.
+  try {
+    await app._lastAction;
+  } catch (err) {
+    console.warn(`${MODULE_ID} | clickAction: action "${actionName}" handler threw:`, err);
+  }
   await flushMicrotasks();
   return btn;
 }


### PR DESCRIPTION
## Summary
Modified action handlers in ChroniclePanelApp to return promises and expose in-flight work via `_lastAction`, enabling integration tests to properly await async operations that complete after the initial DOM event dispatch.

## Key Changes
- **chroniclePanel.js**: Refactored three static action handlers (`#onAddAnnotation`, `#onDeleteEntry`, `#onTogglePin`) to:
  - Wrap async logic in an IIFE that returns a promise
  - Store the promise on `this._lastAction` for test inspection
  - Return the promise instead of being declared as `async`
  - Added explanatory comment about the testing pattern

- **quench.js**: Enhanced `clickAction()` test helper to:
  - Await `app._lastAction` after flushing microtasks, allowing multi-step persistence chains to fully settle
  - Added error handling with console warning if the handler throws
  - Updated comments to clarify the necessity of this pattern for fire-and-forget action dispatchers

## Implementation Details
The change addresses a testing gap where ApplicationV2's action dispatcher invokes handlers fire-and-forget, making it impossible for tests to wait for complex async operations (e.g., JournalEntry.create → createEmbeddedDocuments → setFlag) to complete before re-reading state. By explicitly storing and returning the in-flight promise, tests can now properly synchronize with the full async chain.

https://claude.ai/code/session_01G5weQ1GRhnL2EHboPc1BEs