### PR TITLE
Refactor action handlers to track async operations for testing

### DIFF
--- a/src/art/generator.js
+++ b/src/art/generator.js
@@ -38,7 +38,6 @@ import { storeArtAsset, loadArtAsset }           from "./storage.js";
 import { apiPost } from "../api-proxy.js";
 
 const MODULE_ID   = "starforged-companion";
-const DALLE_URL   = "https://api.openai.com/v1/images/generations";
 const DALLE_MODEL = "dall-e-3";
 
 
@@ -240,46 +239,6 @@ async function attemptDallECall(apiKey, prompt, size, entityId, entityType, isRe
     return null;
   }
 }
-
-/**
- * Handle DALL-E API errors.
- * Returns null for all errors except rate limits (retried once).
- */
-async function handleDallEError(error, apiKey, prompt, size, entityId, entityType, isRetry) {
-  const code = error?.error?.code ?? error?.error?.type ?? "unknown";
-
-  switch (code) {
-    case "content_policy_violation":
-      console.warn(`${MODULE_ID} | Art: content policy violation — portrait will be skipped.`);
-      console.warn(`${MODULE_ID} | Art: prompt was: ${prompt}`);
-      // Non-blocking — entity continues without portrait
-      return null;
-
-    case "rate_limit_exceeded":
-      if (!isRetry) {
-        console.warn(`${MODULE_ID} | Art: rate limited — retrying in 10s`);
-        await delay(10_000);
-        return attemptDallECall(apiKey, prompt, size, entityId, entityType, true);
-      }
-      console.error(`${MODULE_ID} | Art: rate limit retry failed`);
-      return null;
-
-    case "invalid_api_key":
-    case "account_deactivated":
-      notifyBillingError(code);
-      return null;
-
-    case "billing_hard_limit_reached":
-    case "insufficient_quota":
-      notifyBillingError(code);
-      return null;
-
-    default:
-      console.error(`${MODULE_ID} | Art: DALL-E error (${code}):`, error?.error?.message);
-      return null;
-  }
-}
-
 
 // ─────────────────────────────────────────────────────────────────────────────
 // ENTITY LINKING

--- a/src/art/promptBuilder.js
+++ b/src/art/promptBuilder.js
@@ -133,7 +133,7 @@ export function buildRegenerationPrompt(entityType, sourceDescription, entity = 
  * @param {string} entityType
  * @returns {string}
  */
-function extractVisualElements(text, entityType) {
+function extractVisualElements(text, _entityType) {
   if (!text) return "";
 
   // Strip quoted dialogue — not visual
@@ -174,7 +174,7 @@ function extractVisualElements(text, entityType) {
  * @param {string} entityType
  * @returns {string}
  */
-function sanitiseForPolicy(text, entityType) {
+function sanitiseForPolicy(text, _entityType) {
   if (!text) return "";
 
   let s = text;

--- a/src/art/storage.js
+++ b/src/art/storage.js
@@ -105,7 +105,7 @@ export async function loadArtAsset(assetId, campaignState = null) {
  * @param {Object} [campaignState]
  * @returns {Promise<ArtAsset[]>}
  */
-export async function loadEntityAssets(entityId, campaignState = null) {
+export async function loadEntityAssets(entityId, _campaignState = null) {
   const assets = [];
   try {
     for (const entry of game.journal?.contents ?? []) {

--- a/src/integration/quench.js
+++ b/src/integration/quench.js
@@ -1684,7 +1684,6 @@ function registerMovePipelineExtendedTests(quench) {
     (context) => {
       const { describe, it, assert, after } = context;
       const cardIds = [];
-      let actorSnap = null;
       let actor = null;
 
       after(async function () {
@@ -1695,7 +1694,6 @@ function registerMovePipelineExtendedTests(quench) {
         cardIds.length = 0;
         if (actor?.delete) await actor.delete().catch(() => {});
         actor = null;
-        actorSnap = null;
       });
 
       describe("confirmInterpretation — accept / reject", function () {

--- a/src/moves/resolver.js
+++ b/src/moves/resolver.js
@@ -16,7 +16,7 @@
  * Source: Ironsworn: Starforged Reference Guide pp.8-25, Rules Summary pp.116-121
  */
 
-import { MOVES, RANK_TICKS } from "../schemas.js";
+import { MOVES } from "../schemas.js";
 import { rollOracle, rollPaired } from "../oracles/roller.js";
 
 

--- a/src/narration/narrator.js
+++ b/src/narration/narrator.js
@@ -8,7 +8,6 @@ import {
   buildNarratorUserMessage,
   buildSceneUserMessage,
   buildCampaignRecapUserMessage,
-  resolveNarrationPerspective,
   formatEntityCard,
 } from './narratorPrompt.js';
 import { resolveRelevance } from '../context/relevanceResolver.js';
@@ -563,7 +562,7 @@ export function markRecapInjected(sessionId) {
  * @param {string} [options.actorId]  — requesting player's actor ID (unused; reserved)
  * @returns {Promise<string|null>}    — response text, or null on failure/disabled
  */
-export async function interrogateScene(question, campaignState, options = {}) {
+export async function interrogateScene(question, campaignState, _options = {}) {
   const sessionId = campaignState?.currentSessionId ?? null;
 
   if (!getSceneQueryEnabled()) {

--- a/src/ui/entityPanel.js
+++ b/src/ui/entityPanel.js
@@ -570,7 +570,7 @@ export class EntityPanelApp extends ApplicationV2 {
     this.render();
   }
 
-  static async #onBackToList(event, target) {
+  static async #onBackToList(_event, _target) {
     this.#selectedId = null;
     this.render();
   }

--- a/src/ui/progressTracks.js
+++ b/src/ui/progressTracks.js
@@ -232,7 +232,7 @@ export class ProgressTrackApp extends ApplicationV2 {
   // -----------------------------------------------------------------------
 
   /** @override */
-  async _prepareContext(options) {
+  async _prepareContext(_options) {
     const tracks = await loadTracks();
 
     // Annotate each track with derived display values.
@@ -256,7 +256,7 @@ export class ProgressTrackApp extends ApplicationV2 {
   }
 
   /** @override */
-  async _renderHTML(context, options) {
+  async _renderHTML(context, _options) {
     const { active, completed, rankOptions, typeOptions } = context;
 
     const renderTrack = (t) => `
@@ -351,7 +351,7 @@ export class ProgressTrackApp extends ApplicationV2 {
   }
 
   /** @override */
-  _replaceHTML(result, content, options) {
+  _replaceHTML(result, content, _options) {
     // Replace inner content without destroying the window chrome.
     content.innerHTML = '';
     content.append(result);
@@ -493,7 +493,7 @@ export class ProgressTrackApp extends ApplicationV2 {
   /**
    * Add a new track from the input fields at the top of the panel.
    */
-  static #onAddTrack(event, target) {
+  static #onAddTrack(_event, _target) {
     const work = (async () => {
       const panel = this.element.querySelector('.sf-progress-panel');
       const labelInput = panel.querySelector('[name="newLabel"]');

--- a/src/ui/settingsPanel.js
+++ b/src/ui/settingsPanel.js
@@ -892,130 +892,179 @@ export class SettingsPanelApp extends ApplicationV2 {
   }
 
   // -----------------------------------------------------------------------
-  // Action handlers
+  // Action handlers (static — bound via DEFAULT_OPTIONS.actions)
+  //
+  // Each handler records its in-flight promise on `this._lastAction` so that
+  // integration tests can await the full async chain after dispatching a real
+  // DOM click event. ApplicationV2's action dispatcher invokes handlers
+  // fire-and-forget, so without this hook there is no way for a test to wait
+  // for multi-step persistence (e.g. game.settings.set + syncSafetyToCampaignState)
+  // to settle before re-reading state. On hosted environments like Forge VTT,
+  // world-scoped settings writes round-trip to the server and exceed the
+  // microtask window the test helper otherwise relies on.
   // -----------------------------------------------------------------------
 
-  static async #onSwitchTab(event, target) {
-    this.#activeTab = target.dataset.tab;
-    this.render();
+  static #onSwitchTab(event, target) {
+    const work = (async () => {
+      this.#activeTab = target.dataset.tab;
+      this.render();
+    })();
+    this._lastAction = work;
+    return work;
   }
 
-  static async #onSetDial(event, target) {
-    if (!game.user.isGM) return;
-    await setDial(target.dataset.value);
-    this.render();
+  static #onSetDial(event, target) {
+    const work = (async () => {
+      if (!game.user.isGM) return;
+      await setDial(target.dataset.value);
+      this.render();
+    })();
+    this._lastAction = work;
+    return work;
   }
 
-  static async #onAddLine(event, target) {
-    if (!game.user.isGM) return;
-    const input = this.element.querySelector('[name="newLine"]');
-    const text = input?.value.trim();
-    if (!text) return;
-    const lines = getGlobalLines();
-    lines.push(text);
-    await setGlobalLines(lines);   // sync included
-    this.render();
+  static #onAddLine(event, target) {
+    const work = (async () => {
+      if (!game.user.isGM) return;
+      const input = this.element.querySelector('[name="newLine"]');
+      const text = input?.value.trim();
+      if (!text) return;
+      const lines = getGlobalLines();
+      lines.push(text);
+      await setGlobalLines(lines);   // sync included
+      this.render();
+    })();
+    this._lastAction = work;
+    return work;
   }
 
-  static async #onRemoveLine(event, target) {
-    if (!game.user.isGM) return;
-    const idx = Number(target.dataset.index);
-    const lines = getGlobalLines();
-    lines.splice(idx, 1);
-    await setGlobalLines(lines);   // sync included
-    this.render();
+  static #onRemoveLine(event, target) {
+    const work = (async () => {
+      if (!game.user.isGM) return;
+      const idx = Number(target.dataset.index);
+      const lines = getGlobalLines();
+      lines.splice(idx, 1);
+      await setGlobalLines(lines);   // sync included
+      this.render();
+    })();
+    this._lastAction = work;
+    return work;
   }
 
-  static async #onAddVeil(event, target) {
-    if (!game.user.isGM) return;
-    const input = this.element.querySelector('[name="newVeil"]');
-    const text = input?.value.trim();
-    if (!text) return;
-    const veils = getGlobalVeils();
-    veils.push(text);
-    await setGlobalVeils(veils);   // sync included
-    this.render();
+  static #onAddVeil(event, target) {
+    const work = (async () => {
+      if (!game.user.isGM) return;
+      const input = this.element.querySelector('[name="newVeil"]');
+      const text = input?.value.trim();
+      if (!text) return;
+      const veils = getGlobalVeils();
+      veils.push(text);
+      await setGlobalVeils(veils);   // sync included
+      this.render();
+    })();
+    this._lastAction = work;
+    return work;
   }
 
-  static async #onRemoveVeil(event, target) {
-    if (!game.user.isGM) return;
-    const idx = Number(target.dataset.index);
-    const veils = getGlobalVeils();
-    veils.splice(idx, 1);
-    await setGlobalVeils(veils);   // sync included
-    this.render();
+  static #onRemoveVeil(event, target) {
+    const work = (async () => {
+      if (!game.user.isGM) return;
+      const idx = Number(target.dataset.index);
+      const veils = getGlobalVeils();
+      veils.splice(idx, 1);
+      await setGlobalVeils(veils);   // sync included
+      this.render();
+    })();
+    this._lastAction = work;
+    return work;
   }
 
-  static async #onAddPrivateLine(event, target) {
-    const input = this.element.querySelector('[name="newPrivateLine"]');
-    const text = input?.value.trim();
-    if (!text) return;
-    const lines = getPrivateLines();
-    lines.push(text);
-    await setPrivateLines(lines);  // sync included
-    this.render();
+  static #onAddPrivateLine(event, target) {
+    const work = (async () => {
+      const input = this.element.querySelector('[name="newPrivateLine"]');
+      const text = input?.value.trim();
+      if (!text) return;
+      const lines = getPrivateLines();
+      lines.push(text);
+      await setPrivateLines(lines);  // sync included
+      this.render();
+    })();
+    this._lastAction = work;
+    return work;
   }
 
-  static async #onRemovePrivateLine(event, target) {
-    const idx = Number(target.dataset.index);
-    const lines = getPrivateLines();
-    lines.splice(idx, 1);
-    await setPrivateLines(lines);  // sync included
-    this.render();
+  static #onRemovePrivateLine(event, target) {
+    const work = (async () => {
+      const idx = Number(target.dataset.index);
+      const lines = getPrivateLines();
+      lines.splice(idx, 1);
+      await setPrivateLines(lines);  // sync included
+      this.render();
+    })();
+    this._lastAction = work;
+    return work;
   }
 
-  static async #onSaveNarratorSettings(event, target) {
-    if (!game.user.isGM) return;
-    const el = this.element;
+  static #onSaveNarratorSettings(event, target) {
+    const work = (async () => {
+      if (!game.user.isGM) return;
+      const el = this.element;
 
-    const enabled      = el.querySelector('[name="narrationEnabled"]')?.checked ?? true;
-    const model        = el.querySelector('[name="narrationModel"]')?.value         ?? 'claude-sonnet-4-5-20250929';
-    const perspective  = el.querySelector('[name="narrationPerspective"]')?.value   ?? 'auto';
-    const tone         = el.querySelector('[name="narrationTone"]')?.value           ?? 'wry';
-    const lengthRaw    = el.querySelector('[name="narrationLength"]')?.value;
-    const length       = Math.max(1, Math.min(6, Number(lengthRaw) || 3));
-    const instructions = el.querySelector('[name="narrationInstructions"]')?.value.trim() ?? '';
+      const enabled      = el.querySelector('[name="narrationEnabled"]')?.checked ?? true;
+      const model        = el.querySelector('[name="narrationModel"]')?.value         ?? 'claude-sonnet-4-5-20250929';
+      const perspective  = el.querySelector('[name="narrationPerspective"]')?.value   ?? 'auto';
+      const tone         = el.querySelector('[name="narrationTone"]')?.value           ?? 'wry';
+      const lengthRaw    = el.querySelector('[name="narrationLength"]')?.value;
+      const length       = Math.max(1, Math.min(6, Number(lengthRaw) || 3));
+      const instructions = el.querySelector('[name="narrationInstructions"]')?.value.trim() ?? '';
 
-    const autoRecapEnabled = el.querySelector('[name="autoRecapEnabled"]')?.checked ?? true;
-    const sessionGapRaw    = el.querySelector('[name="sessionGapHours"]')?.value;
-    const sessionGapHours  = Math.max(1, Math.min(48, Number(sessionGapRaw) || 4));
-    const recapGmOnly      = el.querySelector('[name="recapGmOnly"]')?.checked ?? true;
+      const autoRecapEnabled = el.querySelector('[name="autoRecapEnabled"]')?.checked ?? true;
+      const sessionGapRaw    = el.querySelector('[name="sessionGapHours"]')?.value;
+      const sessionGapHours  = Math.max(1, Math.min(48, Number(sessionGapRaw) || 4));
+      const recapGmOnly      = el.querySelector('[name="recapGmOnly"]')?.checked ?? true;
 
-    await Promise.all([
-      game.settings.set(MODULE_ID, SETTING.NARRATION_ENABLED,      enabled),
-      game.settings.set(MODULE_ID, SETTING.NARRATION_MODEL,        model),
-      game.settings.set(MODULE_ID, SETTING.NARRATION_PERSPECTIVE,  perspective),
-      game.settings.set(MODULE_ID, SETTING.NARRATION_TONE,         tone),
-      game.settings.set(MODULE_ID, SETTING.NARRATION_LENGTH,       length),
-      game.settings.set(MODULE_ID, SETTING.NARRATION_INSTRUCTIONS, instructions),
-      game.settings.set(MODULE_ID, SETTING.AUTO_RECAP_ENABLED,     autoRecapEnabled),
-      game.settings.set(MODULE_ID, SETTING.SESSION_GAP_HOURS,      sessionGapHours),
-      game.settings.set(MODULE_ID, SETTING.RECAP_GM_ONLY,          recapGmOnly),
-    ]);
+      await Promise.all([
+        game.settings.set(MODULE_ID, SETTING.NARRATION_ENABLED,      enabled),
+        game.settings.set(MODULE_ID, SETTING.NARRATION_MODEL,        model),
+        game.settings.set(MODULE_ID, SETTING.NARRATION_PERSPECTIVE,  perspective),
+        game.settings.set(MODULE_ID, SETTING.NARRATION_TONE,         tone),
+        game.settings.set(MODULE_ID, SETTING.NARRATION_LENGTH,       length),
+        game.settings.set(MODULE_ID, SETTING.NARRATION_INSTRUCTIONS, instructions),
+        game.settings.set(MODULE_ID, SETTING.AUTO_RECAP_ENABLED,     autoRecapEnabled),
+        game.settings.set(MODULE_ID, SETTING.SESSION_GAP_HOURS,      sessionGapHours),
+        game.settings.set(MODULE_ID, SETTING.RECAP_GM_ONLY,          recapGmOnly),
+      ]);
 
-    ui.notifications?.info('Starforged Companion: Narrator settings saved.');
-    this.render();
+      ui.notifications?.info('Starforged Companion: Narrator settings saved.');
+      this.render();
+    })();
+    this._lastAction = work;
+    return work;
   }
 
-  static async #onSaveApiKeys(event, target) {
-    if (!game.user.isGM) return;
+  static #onSaveApiKeys(event, target) {
+    const work = (async () => {
+      if (!game.user.isGM) return;
 
-    const panel      = this.element;
-    const claudeKey  = panel.querySelector('[name="claudeApiKey"]')?.value?.trim();
-    const artKey     = panel.querySelector('[name="artApiKey"]')?.value?.trim();
+      const panel      = this.element;
+      const claudeKey  = panel.querySelector('[name="claudeApiKey"]')?.value?.trim();
+      const artKey     = panel.querySelector('[name="artApiKey"]')?.value?.trim();
 
-    if (claudeKey) {
-      await game.settings.set(MODULE_ID, 'claudeApiKey', claudeKey);
-    }
-    if (artKey) {
-      await game.settings.set(MODULE_ID, 'artApiKey', artKey);
-    }
+      if (claudeKey) {
+        await game.settings.set(MODULE_ID, 'claudeApiKey', claudeKey);
+      }
+      if (artKey) {
+        await game.settings.set(MODULE_ID, 'artApiKey', artKey);
+      }
 
-    if (claudeKey || artKey) {
-      ui.notifications.info('Starforged Companion: API keys saved.');
-    }
+      if (claudeKey || artKey) {
+        ui.notifications.info('Starforged Companion: API keys saved.');
+      }
 
-    this.render();
+      this.render();
+    })();
+    this._lastAction = work;
+    return work;
   }
 }
 

--- a/src/ui/settingsPanel.js
+++ b/src/ui/settingsPanel.js
@@ -479,7 +479,7 @@ async function syncSafetyToCampaignState() {
 // ---------------------------------------------------------------------------
 
 function registerXCardHook() {
-  Hooks.on('chatMessage', (chatLog, message, chatData) => {
+  Hooks.on('chatMessage', (chatLog, message, _chatData) => {
     if (message.trim().toLowerCase() !== '!x') return true;
 
     suppressScene();
@@ -923,7 +923,7 @@ export class SettingsPanelApp extends ApplicationV2 {
     return work;
   }
 
-  static #onAddLine(event, target) {
+  static #onAddLine(_event, _target) {
     const work = (async () => {
       if (!game.user.isGM) return;
       const input = this.element.querySelector('[name="newLine"]');
@@ -938,7 +938,7 @@ export class SettingsPanelApp extends ApplicationV2 {
     return work;
   }
 
-  static #onRemoveLine(event, target) {
+  static #onRemoveLine(_event, target) {
     const work = (async () => {
       if (!game.user.isGM) return;
       const idx = Number(target.dataset.index);
@@ -951,7 +951,7 @@ export class SettingsPanelApp extends ApplicationV2 {
     return work;
   }
 
-  static #onAddVeil(event, target) {
+  static #onAddVeil(_event, _target) {
     const work = (async () => {
       if (!game.user.isGM) return;
       const input = this.element.querySelector('[name="newVeil"]');
@@ -966,7 +966,7 @@ export class SettingsPanelApp extends ApplicationV2 {
     return work;
   }
 
-  static #onRemoveVeil(event, target) {
+  static #onRemoveVeil(_event, target) {
     const work = (async () => {
       if (!game.user.isGM) return;
       const idx = Number(target.dataset.index);
@@ -979,7 +979,7 @@ export class SettingsPanelApp extends ApplicationV2 {
     return work;
   }
 
-  static #onAddPrivateLine(event, target) {
+  static #onAddPrivateLine(_event, _target) {
     const work = (async () => {
       const input = this.element.querySelector('[name="newPrivateLine"]');
       const text = input?.value.trim();
@@ -993,7 +993,7 @@ export class SettingsPanelApp extends ApplicationV2 {
     return work;
   }
 
-  static #onRemovePrivateLine(event, target) {
+  static #onRemovePrivateLine(_event, target) {
     const work = (async () => {
       const idx = Number(target.dataset.index);
       const lines = getPrivateLines();
@@ -1005,7 +1005,7 @@ export class SettingsPanelApp extends ApplicationV2 {
     return work;
   }
 
-  static #onSaveNarratorSettings(event, target) {
+  static #onSaveNarratorSettings(_event, _target) {
     const work = (async () => {
       if (!game.user.isGM) return;
       const el = this.element;
@@ -1042,7 +1042,7 @@ export class SettingsPanelApp extends ApplicationV2 {
     return work;
   }
 
-  static #onSaveApiKeys(event, target) {
+  static #onSaveApiKeys(_event, _target) {
     const work = (async () => {
       if (!game.user.isGM) return;
 
@@ -1194,12 +1194,12 @@ export class MoveConfirmDialog extends ApplicationV2 {
     return super.close(options);
   }
 
-  static async #onAccept(event, target) {
+  static async #onAccept(_event, _target) {
     this.#settle(true);
     this.close({ animate: false });
   }
 
-  static async #onReject(event, target) {
+  static async #onReject(_event, _target) {
     this.#settle(false);
     this.close({ animate: false });
   }


### PR DESCRIPTION
## Summary
This PR refactors action handler methods across the UI layer to properly track in-flight async operations, enabling integration tests to await completion of multi-step persistence chains before re-reading state.

## Key Changes

- **SettingsPanelApp action handlers**: Wrapped all 10 action handler methods (`#onSwitchTab`, `#onSetDial`, `#onAddLine`, `#onRemoveLine`, `#onAddVeil`, `#onRemoveVeil`, `#onAddPrivateLine`, `#onRemovePrivateLine`, `#onSaveNarratorSettings`, `#onSaveApiKeys`) to record their async work on `this._lastAction` before returning. This allows tests to await the full async chain including server round-trips on hosted environments like Forge VTT.

- **MoveConfirmDialog action handlers**: Updated `#onAccept` and `#onReject` to use underscore-prefixed parameters (`_event`, `_target`) to indicate unused parameters.

- **ProgressTrackApp**: Updated `#onAddTrack` and related methods to use underscore-prefixed parameters for unused parameters.

- **EntityPanelApp**: Updated `#onBackToList` to use underscore-prefixed parameters.

- **Unused parameter cleanup**: Marked unused parameters with underscore prefix across multiple files (`settingsPanel.js`, `progressTracks.js`, `promptBuilder.js`, `entityPanel.js`) to improve code clarity and satisfy linter rules.

- **Dead code removal**: Removed unused `DALLE_URL` constant and `handleDallEError` function from `generator.js` that were no longer called.

- **Unused import removal**: Removed unused imports (`resolveNarratorPerspective` from `narrator.js`, `RANK_TICKS` from `resolver.js`, `actorSnap` variable from `quench.js`).

- **Documentation**: Added comprehensive comment block explaining the action handler pattern and why `_lastAction` tracking is necessary for integration testing.

## Implementation Details

The refactored handlers follow a consistent pattern:
```javascript
static #onAction(_event, _target) {
  const work = (async () => {
    // handler logic
  })();
  this._lastAction = work;
  return work;
}
```

This ensures that ApplicationV2's fire-and-forget action dispatcher still returns a promise that tests can await, while the stored reference on `this._lastAction` provides a reliable hook for test helpers to track async completion across server round-trips.

https://claude.ai/code/session_012SAHdS6EMzwgCUoNq79km8