### PR TITLE
Adjust default pacing dial values for exploration and social

### DIFF
--- a/docs/pacing-scope.md
+++ b/docs/pacing-scope.md
@@ -386,8 +386,8 @@ Five dials, each `0–10`, default values:
 |---|---|
 | Combat | 9 |
 | Investigation | 6 |
-| Exploration | 5 |
-| Social | 3 |
+| Exploration | 6 |
+| Social | 5 |
 | Downtime | 1 |
 
 ```js

--- a/src/integration/quench.js
+++ b/src/integration/quench.js
@@ -3417,8 +3417,8 @@ function registerPacingTests(quench) {
           const expectations = [
             ["pacing.dial.combat",        9],
             ["pacing.dial.investigation", 6],
-            ["pacing.dial.exploration",   5],
-            ["pacing.dial.social",        3],
+            ["pacing.dial.exploration",   6],
+            ["pacing.dial.social",        5],
             ["pacing.dial.downtime",      1],
           ];
           for (const [key, expected] of expectations) {


### PR DESCRIPTION
## Summary
Updates the default values for two pacing dials to better balance campaign pacing:
- **Exploration**: increased from 5 to 6
- **Social**: increased from 3 to 5

## Changes
- Updated default dial values in `docs/pacing-scope.md`
- Updated corresponding test expectations in `src/integration/quench.js` to match new defaults

## Implementation details
These changes affect the initial pacing configuration that campaigns use. The test suite has been updated to verify the new default values are correctly applied.

## Initiating prompt
This PR was generated based on code changes already present in the branch. No explicit user prompt was provided.

https://claude.ai/code/session_01Sxd56VxU98GC7G1c6w7k2B