### PR TITLE
fix(factContinuity): stop JSON sidecar leaking into chat card on maxT…

### DIFF
--- a/docs/fact-continuity-scope.md
+++ b/docs/fact-continuity-scope.md
@@ -512,6 +512,7 @@ ledger updates. See §18 Q6 for the alternative considered.
 | Sidecar references subjects with no scope match | Truths still recorded — the player named someone we don't have a card for, which is the point of free-text subjects. |
 | Sidecar declares a truth that contradicts an existing truth | Recorded as-is; the consistency-check pass (§11), if enabled, flags it. Manual override remains the GM's call. |
 | Sidecar arrives without prose | Treat as failure; post fallback card; do not record. |
+| Sidecar truncated mid-JSON by `maxTokens` (opening `` ```json `` fence but no closing `` ``` ``) | Strip from the opening fence forward in `extractSidecar` so the partial JSON does not bleed into the chat card. Log a parseError with "truncated by maxTokens" hint; do not apply partial data to the ledger. The narrator caller adds `SIDECAR_TOKEN_HEADROOM = 300` to every `maxTokens` budget when fact-continuity is enabled, so this should be rare — the defensive strip is the safety net for unusually long narrations. (Bug observed on Forge with v1.3.0; fix in `src/factContinuity/sidecarParser.js` + `narrator.js maxTokensWithSidecar`.) |
 
 Failure must not block the move pipeline. The narrator's prose is the
 contract with the player; ledger updates are best-effort downstream of

--- a/src/factContinuity/sidecarParser.js
+++ b/src/factContinuity/sidecarParser.js
@@ -47,6 +47,24 @@ export function extractSidecar(rawText) {
 
   const matches = [...rawText.matchAll(FENCE_PATTERN)];
   if (!matches.length) {
+    // Defensive: if the model emitted an opening ```json fence but the
+    // closing ``` never arrived — typically because maxTokens cut the
+    // response mid-sidecar — the regex above will not match. Without this
+    // fallback, the truncated JSON bleeds verbatim into the chat card
+    // (observed on Forge with v1.3.0). Strip from the opening fence
+    // forward, surface a parseError so the caller logs the cause, and
+    // return sidecar=null so partial data is not applied to the ledger.
+    const openIdx = rawText.search(/```json\b/i);
+    if (openIdx >= 0) {
+      const prose = rawText.slice(0, openIdx).replace(/\s+$/u, '');
+      return {
+        prose,
+        sidecar:    null,
+        parseError: new Error(
+          'Sidecar opening fence found but no closing fence — narrator response likely truncated by maxTokens.',
+        ),
+      };
+    }
     return { prose: rawText, sidecar: null, parseError: null };
   }
 

--- a/src/narration/narrator.js
+++ b/src/narration/narrator.js
@@ -56,6 +56,30 @@ const MODULE_ID      = 'starforged-companion';
 const ANTHROPIC_URL  = 'https://api.anthropic.com/v1/messages';
 const RETRY_DELAY_MS = 5000;
 
+// Extra tokens reserved for the fact-continuity sidecar JSON when it ships
+// alongside narrator prose. A typical sidecar with 2–4 newTruths and 2–4
+// stateChanges runs ~150–250 tokens; we budget 300 to leave the prose its
+// full configured length plus comfortable headroom for the structured
+// block. Without this, maxTokens hits mid-JSON and the truncated fence
+// leaks into the chat card (observed on Forge with v1.3.0).
+const SIDECAR_TOKEN_HEADROOM = 300;
+
+/**
+ * Compute the maxTokens budget for a narrator API call, adding headroom
+ * for the fact-continuity sidecar when the feature is enabled. Reads the
+ * setting defensively (try/catch) so unit tests without registered
+ * settings still get the headroom.
+ */
+function maxTokensWithSidecar(baseMaxTokens) {
+  let fcEnabled = true;
+  try {
+    fcEnabled = globalThis.game?.settings?.get?.(MODULE_ID, 'factContinuity.enabled') ?? true;
+  } catch {
+    fcEnabled = true;
+  }
+  return fcEnabled ? (baseMaxTokens ?? 0) + SIDECAR_TOKEN_HEADROOM : baseMaxTokens;
+}
+
 // Tracks whether a campaign recap has been injected into the narrator prompt
 // for the current session. Reset when the session ID changes.
 let _lastRecapInjectedSessionId = null;
@@ -172,7 +196,7 @@ export async function narrateResolution(resolution, contextPacket, campaignState
       systemPrompt,
       userMessage,
       model:     settings.narrationModel,
-      maxTokens: settings.narrationMaxTokens,
+      maxTokens: maxTokensWithSidecar(settings.narrationMaxTokens),
     });
     const narration = applyNarratorSidecar(raw, campaignState, {
       moveId:           resolution?.moveId,
@@ -207,7 +231,7 @@ export async function narrateResolution(resolution, contextPacket, campaignState
         const raw = await callNarratorAPI({
           apiKey, systemPrompt, userMessage,
           model:     settings.narrationModel,
-          maxTokens: settings.narrationMaxTokens,
+          maxTokens: maxTokensWithSidecar(settings.narrationMaxTokens),
         });
         const narration = applyNarratorSidecar(raw, campaignState, {
           moveId:           resolution?.moveId,
@@ -533,7 +557,7 @@ export async function getCampaignRecap(campaignState, options = {}) {
       systemPrompt,
       userMessage,
       model:     settings.narrationModel,
-      maxTokens: 600,
+      maxTokens: maxTokensWithSidecar(600),
     });
 
     if (text?.trim() && game.user?.isGM) {
@@ -695,7 +719,7 @@ export async function interrogateScene(question, campaignState, _options = {}) {
       systemPrompt,
       userMessage,
       model:     settings.narrationModel,
-      maxTokens: 200,
+      maxTokens: maxTokensWithSidecar(200),
     });
     const response = applyNarratorSidecar(raw, campaignState, { moveId: null, playerNarration: question });
 
@@ -714,7 +738,7 @@ export async function interrogateScene(question, campaignState, _options = {}) {
         const raw = await callNarratorAPI({
           apiKey, systemPrompt, userMessage,
           model:     settings.narrationModel,
-          maxTokens: 200,
+          maxTokens: maxTokensWithSidecar(200),
         });
         const response = applyNarratorSidecar(raw, campaignState, { moveId: null, playerNarration: question });
         if (response?.trim()) {
@@ -789,7 +813,7 @@ export async function narratePacedInput(playerText, campaignState, options = {})
     const raw = await callNarratorAPI({
       apiKey, systemPrompt, userMessage,
       model:     settings.narrationModel,
-      maxTokens: settings.narrationMaxTokens,
+      maxTokens: maxTokensWithSidecar(settings.narrationMaxTokens),
     });
     const text = applyNarratorSidecar(raw, campaignState, { moveId: null, playerNarration: playerText });
 
@@ -810,7 +834,7 @@ export async function narratePacedInput(playerText, campaignState, options = {})
         const raw = await callNarratorAPI({
           apiKey, systemPrompt, userMessage,
           model:     settings.narrationModel,
-          maxTokens: settings.narrationMaxTokens,
+          maxTokens: maxTokensWithSidecar(settings.narrationMaxTokens),
         });
         const text = applyNarratorSidecar(raw, campaignState, { moveId: null, playerNarration: playerText });
         if (text?.trim()) {

--- a/tests/unit/factContinuity.test.js
+++ b/tests/unit/factContinuity.test.js
@@ -101,6 +101,28 @@ describe('extractSidecar', () => {
     expect(prose).not.toMatch(/```/);
   });
 
+  it('strips an unterminated ```json opening (truncated by maxTokens) and surfaces parseError', () => {
+    // Reproduces the v1.3.0 Forge bug: maxTokens cut the response mid-JSON
+    // so the closing ``` never arrived. Without this fallback, the regex
+    // failed to match and the partial JSON bled into the chat card as
+    // visible prose.
+    const text = [
+      'The bridge hatch slides open to reveal Vray.',
+      '',
+      '```json',
+      '{ "newTruths": [{ "subject": "Vray", "fact": "Compact build" }],',
+      '  "stateChanges": [{ "subject": "scene", "attribute": "location", "value": "',
+    ].join('\n');
+
+    const { prose, sidecar, parseError } = extractSidecar(text);
+    expect(prose).toBe('The bridge hatch slides open to reveal Vray.');
+    expect(prose).not.toMatch(/```/);
+    expect(prose).not.toMatch(/newTruths/);
+    expect(sidecar).toBeNull();
+    expect(parseError).toBeInstanceOf(Error);
+    expect(parseError.message).toMatch(/truncated/i);
+  });
+
   it('returns empty arrays when sidecar omits one of the keys', () => {
     const text = [
       'Prose.',


### PR DESCRIPTION
…okens truncation

Observed on Forge v1.3.0 (screenshot — narrator card ends mid-JSON with "value": " cut off). The model's response was truncated by maxTokens mid-sidecar, so the closing ``` fence never arrived. The FENCE_PATTERN regex in extractSidecar requires a matched opening + closing fence; without a closing ``` it returned no match, the truncated JSON was left in the prose, and the whole thing posted to chat verbatim. The fact-continuity ledger silently lost data on every truncated turn too since sidecar=null.

Two-part fix:

- src/factContinuity/sidecarParser.js — defensive: when FENCE_PATTERN finds no complete match but the text contains an unterminated ```json opening, strip from the opening fence forward, return prose without the partial JSON, and surface a parseError with "truncated by maxTokens" hint. sidecar stays null (partial data is never applied to the ledger). Regression test in tests/unit/factContinuity.test.js ("strips an unterminated ```json opening …") reproduces the exact Forge symptom.

- src/narration/narrator.js — preventive: new SIDECAR_TOKEN_HEADROOM constant (300 tokens) and maxTokensWithSidecar(base) helper, applied at every callNarratorAPI site that emits a sidecar:
  - narrateResolution primary + retry        (settings.narrationMaxTokens + 300)
  - interrogateScene primary + retry         (200 + 300)
  - narratePacedInput primary + retry        (settings.narrationMaxTokens + 300)
  - getCampaignRecap one-shot                (600 + 300)
  Reads factContinuity.enabled defensively (try/catch) so unit tests
  without registered settings still receive the headroom. When
  fact-continuity is disabled, the base maxTokens passes through
  unchanged.

A typical sidecar with 2–4 newTruths and 2–4 stateChanges runs ~150–250 tokens; 300 leaves the prose its full configured length plus comfortable headroom. Without this, the default 300-token narrationMaxTokens budget was easily blown by even mid-length prose plus a structured sidecar (Vray case: ~250-token prose + ~250-token sidecar = ~500 tokens needed).

docs/fact-continuity-scope.md §7.2 failure-modes table grows a row for the truncation case so future readers see both the symptom and the defensive strip + token-headroom strategy.

Verification: npm test 1137/1137 (was 1136 + 1 truncation regression test); npm run lint clean.

https://claude.ai/code/session_017w3527eYpAMmwXEF6XDGeF