### PR TITLE
test(quench): bump timeout on 3 Forge-latency-sensitive settings-writ…

### DIFF
--- a/src/integration/quench.js
+++ b/src/integration/quench.js
@@ -2921,6 +2921,12 @@ function registerEntityPanelActionsTests(quench) {
 
       describe("setCurrentLocation — DOM click on a seeded Settlement", function () {
         it("writes campaignState.currentLocationId / currentLocationType, and the toggle clears them", async function () {
+          // Forge round-trip: each set/clear does two world-scoped writes,
+          // and `awaitRender(app)` waits for both. The combined chain
+          // routinely exceeds Mocha's 2 s default on loaded Forge. Same
+          // pattern as the recap-refresh + assembler-sector tests fixed
+          // in PR #105.
+          this.timeout(20000);
           if (!app || !testSettlementId) { this.skip(); return; }
 
           // Make sure we're on the list view, then click into the settlement detail.
@@ -3443,6 +3449,9 @@ function registerSettingsPanelTests(quench) {
 
       describe("setDial — DOM click", function () {
         it("clicking setDial[data-value=chaotic] persists the setting", async function () {
+          // Forge world-scoped write + restore round-trip — see the
+          // setCurrentLocation timeout note above.
+          this.timeout(20000);
           if (!app) { this.skip(); return; }
           const before = game.settings.get(MODULE_ID, "mischiefDial");
           try {
@@ -3457,6 +3466,9 @@ function registerSettingsPanelTests(quench) {
 
       describe("addLine / removeLine — Safety tab", function () {
         it("addLine writes through to globalSafetyLines", async function () {
+          // Forge world-scoped write + restore round-trip — see the
+          // setCurrentLocation timeout note above.
+          this.timeout(20000);
           if (!app) { this.skip(); return; }
           await clickAction(app, "switchTab", { tab: "safety" });
           await awaitRender(app);


### PR DESCRIPTION
…e tests

Three Quench tests time out at 2 s on Forge in v1.3.1 — same shape as the recap-refresh + assembler-sector timeouts PR #105 already addressed. Forge round-trips world-scoped settings writes through the server (1.5–2 s per hop × 2 hops); Mocha's 2 s default is too tight. Not a fact-continuity regression — pre-existing Forge timing variance on tests that were always near the edge.

Tests fixed:

- entityPanelActions: setCurrentLocation — DOM click on a seeded Settlement → writes campaignState.currentLocationId / currentLocationType, and the toggle clears them. Two world-scoped writes plus two awaitRender chains.

- settingsPanel: setDial — clicking setDial[data-value=chaotic] persists the setting. One write + one restore.

- settingsPanel: addLine — addLine writes through to globalSafetyLines. One write + one restore + a tab switch.

All three get `this.timeout(20000)` with an inline comment pointing at the same root cause and PR #105 precedent. No production source touched.

Verification: npm test 1137/1137 (unchanged — these are live-Forge tests; the Vitest suite was already passing). npm run lint clean.

The screenshot from v1.3.1 showed "5 failed" total. Two failures weren't visible in the captured frames. If those surface on the next Forge run, the same pattern (this.timeout(20000) + inline pointer comment) should apply.

https://claude.ai/code/session_017w3527eYpAMmwXEF6XDGeF