### PR TITLE
fix: v1.6.1 playtest fixes — burn momentum (F12) + vignette &lt;npc&gt; leak (F9a/F22a)

### DIFF
--- a/src/art/generator.js
+++ b/src/art/generator.js
@@ -242,6 +242,30 @@ async function linkPortraitToEntity(journalEntryId, entityType, artAssetId) {
  * have no image-bearing document. GM-gated (uploads require GM). Non-blocking:
  * a missing Actor portrait is preferable to a broken seed or narration.
  */
+/**
+ * Embed (or replace) a portrait image block at the top of a starship's Notes
+ * HTML (F5). Wrapped in a marker div so it can be swapped on regeneration
+ * without duplicating, and so it's stripped cleanly before re-adding.
+ *
+ * @param {string} notesHtml  existing system.notes
+ * @param {string} imgPath    uploaded image path / URL
+ * @returns {string}
+ */
+export function withPortraitInNotes(notesHtml, imgPath) {
+  const existing = String(notesHtml ?? "");
+  // Remove any prior companion art block (idempotent on regeneration).
+  const stripped = existing.replace(
+    /<div class="sf-ship-portrait"[\s\S]*?<\/div>/,
+    "",
+  ).trimStart();
+  if (!imgPath) return stripped;
+  const block =
+    `<div class="sf-ship-portrait" style="text-align:center;margin-bottom:0.5em;">` +
+    `<img src="${imgPath}" alt="Ship portrait" style="max-width:100%;border-radius:6px;"/>` +
+    `</div>`;
+  return block + stripped;
+}
+
 async function attachPortraitToActor(journalEntryId, entityType, b64, assetId) {
   try {
     if (!b64) return;
@@ -254,10 +278,21 @@ async function attachPortraitToActor(journalEntryId, entityType, b64, assetId) {
     const path = await uploadPortraitImage(b64, `${document.id}-${assetId}.png`);
     if (!path) return;
 
-    await document.update({
+    const update = {
       img:                          path,
       "prototypeToken.texture.src": path,
-    });
+    };
+
+    // Mirror the portrait into the starship's Notes tab (F5): the sheet's
+    // header icon is small, so embed a larger copy at the top of the notes
+    // HTML. Idempotent — replace any prior companion art block rather than
+    // stacking. Only starships have a meaningful Notes tab here.
+    if (entityType === "ship") {
+      const notes = String(document.system?.notes ?? "");
+      update["system.notes"] = withPortraitInNotes(notes, path);
+    }
+
+    await document.update(update);
     console.log(`${MODULE_ID} | Art: attached portrait to Actor ${document.id} (${path})`);
   } catch (err) {
     console.warn(`${MODULE_ID} | Art: attachPortraitToActor failed:`, err?.message ?? err);

--- a/src/audio/index.js
+++ b/src/audio/index.js
@@ -39,6 +39,32 @@ export const AUDIO_SOCKET_NAME = `module.${MODULE_ID}`;
 const _sessionsByCardId = new WeakMap();
 let _gestureOverlayShown = false;
 
+// Cards we have already auto-played, by message id. A narrator card re-renders
+// on every update (e.g. clicking its "Roll <move>" button updates the message),
+// and onNarratorCardRendered runs each time — without this guard, autoplay
+// would re-fire on every re-render and replay the audio (F14). Click-to-play is
+// unaffected; this only gates the automatic path.
+const _autoplayedCardIds = new Set();
+
+/** Test-only — clears the autoplay-once guard between cases. */
+export function _resetAutoplayGuardForTests() { _autoplayedCardIds.clear(); }
+
+/**
+ * Should this card auto-play right now? True at most once per card id — the
+ * first call for a given id claims it and returns true; subsequent calls (card
+ * re-renders, e.g. after its "Roll <move>" button updates the message) return
+ * false so autoplay never replays the audio (F14). Mutates the guard set.
+ *
+ * @param {string} cardId  message.id
+ * @returns {boolean}
+ */
+export function claimAutoplayOnce(cardId) {
+  if (cardId == null) return false;
+  if (_autoplayedCardIds.has(cardId)) return false;
+  _autoplayedCardIds.add(cardId);
+  return true;
+}
+
 // ---------------------------------------------------------------------------
 // Setting accessors
 // ---------------------------------------------------------------------------
@@ -259,8 +285,9 @@ export async function onNarratorCardRendered(message, root) {
     });
   }
 
-  // Optional auto-play.
-  if (getSetting("audio.autoplay", false) === true) {
+  // Optional auto-play — once per card. A re-render (e.g. after the card's
+  // "Roll <move>" button updates the message) must not replay the audio (F14).
+  if (getSetting("audio.autoplay", false) === true && claimAutoplayOnce(message.id)) {
     if (!userGestureReceived()) {
       showGestureOverlay(root, async () => {
         await togglePlayback(message, fresh, rawProse);

--- a/src/audio/playback.js
+++ b/src/audio/playback.js
@@ -243,16 +243,22 @@ export class PlaybackSession {
       let settled = false;
       const finish = () => { if (settled) return; settled = true; resolve(); };
       const fail   = (err) => { if (settled) return; settled = true; reject(err); };
+      // Completion is signalled by the Sound's 'end' (clip finished) or 'stop'
+      // (interrupted) event — NOT by play()'s promise. Foundry v13 Sound.play()
+      // resolves at playback START, so finishing on it would advance to the next
+      // segment immediately and play it on top of this one (F11: the two NPC/
+      // narrator voices overlapped). We only listen for end/stop here.
+      //
       // Foundry v13 Sound only supports pause/start/stop/end/load events —
       // attaching an "error" listener throws synchronously. Failures during
       // load or decode surface via sound.play()'s promise rejection below.
       sound.addEventListener?.("end",  finish, { once: true });
       sound.addEventListener?.("stop", finish, { once: true });
-      sound.play({ volume: this.volume }).then(
-        // Some Sound implementations resolve play() at completion; others at start.
-        // If play() resolves AND no 'end' event has fired, we still treat the
-        // resolved promise as a hint that the sound is done.
-        () => setTimeout(finish, 0),
+      // Guard: a Sound implementation that never emits 'end' (or resolves play()
+      // only at completion) must still advance — fall back to the resolved
+      // play() promise so the queue can't deadlock, but only as a last resort.
+      Promise.resolve(sound.play({ volume: this.volume })).then(
+        () => { if (sound?.addEventListener == null) finish(); },
         fail,
       );
     });

--- a/src/entities/connection.js
+++ b/src/entities/connection.js
@@ -74,10 +74,12 @@ export async function createConnection(data, campaignState, { persist = true } =
     flags:  { [MODULE_ID]: { entityType: "connection", entityId: id } },
   });
 
-  // Create the page that holds the data
+  // Create the page that holds the data. Render a body from the description so
+  // the page isn't blank — the data also lives on the flag (F19, theme T3).
   await entry.createEmbeddedDocuments("JournalEntryPage", [{
     name:  "Connection Data",
     type:  "text",
+    text:  { format: 1, content: renderEntityBody(connection) },
     flags: { [MODULE_ID]: { [FLAG_KEY]: connection } },
   }]);
 
@@ -463,6 +465,26 @@ function resolveJournalId(connectionId, campaignState) {
     if (entry?.flags?.[MODULE_ID]?.entityId === connectionId) return journalId;
   }
   return null;
+}
+
+/**
+ * Render the Connection's descriptive fields into HTML for the page body so
+ * the JournalEntryPage isn't blank (F19 / theme T3). The full record still
+ * lives on the page flag for the entity panel.
+ */
+export function renderEntityBody(connection) {
+  const esc = (s) => String(s ?? "")
+    .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  const out = [];
+  const meta = (label, value) =>
+    value ? out.push(`<p><strong>${esc(label)}:</strong> ${esc(value)}</p>`) : null;
+  meta("Role", connection?.role);
+  meta("Rank", connection?.rank);
+  meta("Relationship", connection?.relationshipType);
+  if (connection?.description) out.push(`<p>${esc(connection.description)}</p>`);
+  if (connection?.motivation)  out.push(`<p><strong>Motivation:</strong> ${esc(connection.motivation)}</p>`);
+  if (connection?.notes)       out.push(`<p>${esc(connection.notes)}</p>`);
+  return out.join("");
 }
 
 function generateId() {

--- a/src/entities/creature.js
+++ b/src/entities/creature.js
@@ -82,6 +82,7 @@ export async function createCreature(data, campaignState) {
   await entry.createEmbeddedDocuments("JournalEntryPage", [{
     name:  "Creature Data",
     type:  "text",
+    text:  { format: 1, content: renderEntityBody(creature) },
     flags: { [MODULE_ID]: { [FLAG_KEY]: creature } },
   }]);
 
@@ -168,6 +169,29 @@ export function formatForContext(creature) {
   if (creature.narratorNotes) parts.push(`Note: ${creature.narratorNotes}`);
 
   return parts.join(" | ");
+}
+
+/**
+ * Render the Creature's descriptive fields into HTML for the page body so the
+ * JournalEntryPage isn't blank (F19 / theme T3). The full record still lives
+ * on the page flag for the entity panel.
+ */
+export function renderEntityBody(creature) {
+  const esc = (s) => String(s ?? "")
+    .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  const out = [];
+  const meta = (label, value) =>
+    value ? out.push(`<p><strong>${esc(label)}:</strong> ${esc(value)}</p>`) : null;
+  meta("Environment", creature?.environment);
+  meta("Rank", creature?.rank);
+  if (Array.isArray(creature?.aspect) && creature.aspect.length) {
+    meta("Aspect", creature.aspect.join(", "));
+  }
+  meta("Behavior", creature?.behavior);
+  if (creature?.form && creature.form !== creature?.description) out.push(`<p>${esc(creature.form)}</p>`);
+  if (creature?.description) out.push(`<p>${esc(creature.description)}</p>`);
+  if (creature?.notes) out.push(`<p>${esc(creature.notes)}</p>`);
+  return out.join("");
 }
 
 function generateId() {

--- a/src/entities/faction.js
+++ b/src/entities/faction.js
@@ -87,6 +87,7 @@ export async function createFaction(data, campaignState) {
   await entry.createEmbeddedDocuments("JournalEntryPage", [{
     name:  "Faction Data",
     type:  "text",
+    text:  { format: 1, content: renderEntityBody(faction) },
     flags: { [MODULE_ID]: { [FLAG_KEY]: faction } },
   }]);
 
@@ -212,6 +213,27 @@ export function formatForContext(faction) {
   if (faction.loremasterNotes) parts.push(`Note: ${faction.loremasterNotes}`);
 
   return parts.join(" | ");
+}
+
+/**
+ * Render the Faction's descriptive fields into HTML for the page body so the
+ * JournalEntryPage isn't blank (F19 / theme T3). The full record still lives
+ * on the page flag for the entity panel.
+ */
+export function renderEntityBody(faction) {
+  const esc = (s) => String(s ?? "")
+    .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  const out = [];
+  const meta = (label, value) =>
+    value ? out.push(`<p><strong>${esc(label)}:</strong> ${esc(value)}</p>`) : null;
+  meta("Type", faction?.subtype ? `${faction.type}: ${faction.subtype}` : faction?.type);
+  if (faction?.relationship && faction.relationship !== "unknown") {
+    meta("Stance", faction.relationship.replace(/_/g, " "));
+  }
+  if (faction?.description) out.push(`<p>${esc(faction.description)}</p>`);
+  meta("Quirk", faction?.quirk);
+  if (faction?.notes) out.push(`<p>${esc(faction.notes)}</p>`);
+  return out.join("");
 }
 
 function generateId() {

--- a/src/index.js
+++ b/src/index.js
@@ -2323,7 +2323,39 @@ Hooks.once("init", () => {
   console.log(`${MODULE_ID} | Initialising`);
   registerCoreSettings();
   registerUISettings();
+  registerCompanionControlLayer();
 });
+
+/**
+ * Register an empty Canvas InteractionLayer for the Companion's own
+ * scene-control group (F16). A top-level scene-control group must reference a
+ * canvas layer; selecting the group activates that layer. We don't draw
+ * anything — the layer exists only so the group is selectable without hijacking
+ * Foundry's token tools (where the buttons previously lived and vanished when
+ * another group was selected). Mirrors foundry-ironsworn's own pattern
+ * (vendor/foundry-ironsworn/src/module/features/sceneButtons.ts).
+ */
+function registerCompanionControlLayer() {
+  try {
+    const InteractionLayer = foundry?.canvas?.layers?.InteractionLayer;
+    if (!InteractionLayer || !globalThis.CONFIG?.Canvas?.layers) return;
+    class StarforgedCompanionLayer extends InteractionLayer {
+      static get layerOptions() {
+        return foundry.utils.mergeObject(super.layerOptions, {
+          zIndex: 180,
+          name:   "starforgedCompanion",
+        });
+      }
+      get placeables() { return []; }
+    }
+    CONFIG.Canvas.layers.starforgedCompanion = {
+      layerClass: StarforgedCompanionLayer,
+      group:      "primary",
+    };
+  } catch (err) {
+    console.warn(`${MODULE_ID} | could not register companion control layer:`, err);
+  }
+}
 
 Hooks.once("ready", () => {
   console.log(`${MODULE_ID} | Ready`);
@@ -2482,101 +2514,70 @@ Hooks.once("closeWorld", async () => {
   await game.settings.set(MODULE_ID, "campaignState", campaignState);
 });
 
+/**
+ * Build the Companion's toolbar tools as an object keyed by tool name. Shared
+ * between the dedicated Companion control group (F16) and the legacy tokens-group
+ * fallback. `onChange` exists because v13 requires it on the tool object, but it
+ * is never called for button:true tools — the real handlers are bound in the
+ * renderSceneControls hook below (two-hook pattern).
+ */
+function buildCompanionTools() {
+  const isGM = game.user.isGM;
+  return {
+    sfSession:      { name: "sfSession",      title: "Session",             icon: "fas fa-play-circle", button: true, onChange: () => openSessionPanel() },
+    progressTracks: { name: "progressTracks", title: "Progress Tracks",     icon: "fas fa-tasks",       button: true, onChange: () => openProgressTracks() },
+    entityPanel:    { name: "entityPanel",    title: "Entities",            icon: "fas fa-users",       button: true, onChange: () => openEntityPanel() },
+    chronicle:      { name: "chronicle",      title: "Character Chronicle", icon: "fas fa-book-open",    button: true, onChange: () => openChroniclePanel() },
+    sfSettings:     { name: "sfSettings",     title: "Companion Settings",  icon: "fas fa-shield-alt",   button: true, visible: isGM, onChange: () => openSettingsPanel() },
+    sectorCreator:  { name: "sectorCreator",  title: "Sector Creator",      icon: "fas fa-map",          button: true, visible: isGM, onChange: () => {} },
+    worldJournal:   { name: "worldJournal",   title: "World Journal",       icon: "fas fa-book",         button: true, visible: isGM, onChange: () => {} },
+    worldTruths:    { name: "worldTruths",    title: "World Truths",        icon: "fas fa-scroll",       button: true, visible: isGM, onChange: () => {} },
+    clocks:         { name: "clocks",         title: "Clocks",              icon: "fas fa-clock",        button: true, onChange: () => {} },
+    customOracles:  { name: "customOracles",  title: "Custom Oracles",      icon: "fas fa-table-list",   button: true, visible: isGM, onChange: () => {} },
+  };
+}
+
 Hooks.on("getSceneControlButtons", (controls) => {
-  console.log(`${MODULE_ID} | getSceneControlButtons fired, keys:`,
-    Object.keys(controls ?? {}));
+  const tools = buildCompanionTools();
 
-  // v13: controls is an object keyed by group name
-  // Access tokens group directly — do not use Object.values or find()
-  const tokenControls = controls?.tokens ?? controls?.token;
-  console.log(`${MODULE_ID} | tokenControls:`, tokenControls?.name,
-    "tools:", Object.keys(tokenControls?.tools ?? {}));
-
-  if (!tokenControls) {
-    console.warn(`${MODULE_ID} | No token controls found — buttons not registered`);
-    return;
+  // Preferred: the Companion's own top-level scene-control group (F16) so the
+  // buttons no longer ride inside Foundry's token tools (where selecting any
+  // other group hid them, with no way back). v13 — controls is an Object keyed
+  // by group name; v12 — controls is an Array. Mirrors foundry-ironsworn's own
+  // group registration. Wrapped defensively: any failure falls back to the
+  // tokens group so the buttons can never fully disappear.
+  let placedInOwnGroup = false;
+  try {
+    const group = {
+      name:    "starforgedCompanion",
+      title:   "Starforged Companion",
+      icon:    "fas fa-meteor",
+      layer:   "starforgedCompanion",
+      visible: true,
+      tools,
+    };
+    if (Array.isArray(controls)) {
+      controls.push(group);
+      placedInOwnGroup = true;
+    } else if (controls && typeof controls === "object") {
+      controls.starforgedCompanion = group;
+      placedInOwnGroup = true;
+    }
+  } catch (err) {
+    console.warn(`${MODULE_ID} | companion control group registration failed:`, err);
   }
 
-  // v13: tools is an object keyed by tool name
-  // Do NOT reassign tokenControls.tools — add keys to whatever is there
-  tokenControls.tools ??= {};
-
-  // v13: use onChange not onClick — confirmed from official API docs
-  tokenControls.tools.sfSession = {
-    name:     "sfSession",
-    title:    "Session",
-    icon:     "fas fa-play-circle",
-    button:   true,
-    onChange: () => openSessionPanel(),
-  };
-  tokenControls.tools.progressTracks = {
-    name:     "progressTracks",
-    title:    "Progress Tracks",
-    icon:     "fas fa-tasks",
-    button:   true,
-    onChange: () => openProgressTracks(),
-  };
-  tokenControls.tools.entityPanel = {
-    name:     "entityPanel",
-    title:    "Entities",
-    icon:     "fas fa-users",
-    button:   true,
-    onChange: () => openEntityPanel(),
-  };
-  tokenControls.tools.chronicle = {
-    name:     "chronicle",
-    title:    "Character Chronicle",
-    icon:     "fas fa-book-open",
-    button:   true,
-    onChange: () => openChroniclePanel(),
-  };
-  tokenControls.tools.sfSettings = {
-    name:     "sfSettings",
-    title:    "Companion Settings",
-    icon:     "fas fa-shield-alt",
-    button:   true,
-    visible:  game.user.isGM,
-    onChange: () => openSettingsPanel(),
-  };
-  tokenControls.tools.sectorCreator = {
-    name:     "sectorCreator",
-    title:    "Sector Creator",
-    icon:     "fas fa-map",
-    button:   true,
-    visible:  game.user.isGM,
-    onChange: () => {},
-  };
-  tokenControls.tools.worldJournal = {
-    name:     "worldJournal",
-    title:    "World Journal",
-    icon:     "fas fa-book",
-    button:   true,
-    visible:  game.user.isGM,
-    onChange: () => {},
-  };
-  tokenControls.tools.worldTruths = {
-    name:     "worldTruths",
-    title:    "World Truths",
-    icon:     "fas fa-scroll",
-    button:   true,
-    visible:  game.user.isGM,
-    onChange: () => {},
-  };
-  tokenControls.tools.clocks = {
-    name:     "clocks",
-    title:    "Clocks",
-    icon:     "fas fa-clock",
-    button:   true,
-    onChange: () => {},
-  };
-  tokenControls.tools.customOracles = {
-    name:     "customOracles",
-    title:    "Custom Oracles",
-    icon:     "fas fa-table-list",
-    button:   true,
-    visible:  game.user.isGM,
-    onChange: () => {},
-  };
+  // Fallback: if the dedicated group couldn't be placed (unexpected controls
+  // shape), register into the tokens group as before so the buttons still show.
+  if (!placedInOwnGroup) {
+    const tokenControls = controls?.tokens ?? controls?.token;
+    if (!tokenControls) {
+      console.warn(`${MODULE_ID} | No control group available — buttons not registered`);
+      return;
+    }
+    tokenControls.tools ??= {};
+    Object.assign(tokenControls.tools, tools);
+  }
 });
 
 // Foundry v13 does not invoke onChange for `button: true` tools registered via

--- a/src/integration/quench.js
+++ b/src/integration/quench.js
@@ -4224,19 +4224,41 @@ function registerToolbarTests(quench) {
       const { describe, it, assert } = context;
 
       describe("getSceneControlButtons — registers companion tools", function () {
-        it("populates token tool entries for the companion buttons", async function () {
-          // Build a minimal controls object as v13 would, then fire the hook.
+        it("creates a dedicated Starforged Companion control group with the buttons", async function () {
+          // v13: controls is an Object keyed by group name. The Companion now
+          // registers its own top-level group (F16) instead of riding inside
+          // the tokens group, so selecting another group no longer hides it.
           const controls = { tokens: { name: "tokens", tools: {} } };
           Hooks.callAll("getSceneControlButtons", controls);
-          const tools = controls.tokens.tools;
-          assert.isObject(tools, "tools should be populated");
-          // Expected button keys per CLAUDE.md / source — at minimum these:
-          const expected = ["progressTracks", "entityPanel", "chronicle"];
+
+          const group = controls.starforgedCompanion;
+          assert.isObject(group, "a starforgedCompanion control group should be registered");
+          assert.isObject(group.tools, "the group should carry a tools object");
+          const expected = ["sfSession", "progressTracks", "entityPanel", "chronicle", "clocks"];
           for (const k of expected) {
-            const has = Object.values(tools).some(t =>
-              t?.name === k || (typeof tools[k] === "object" && tools[k] !== null));
-            assert.isTrue(has, `tool "${k}" should be registered`);
+            assert.isTrue(
+              group.tools[k]?.name === k,
+              `tool "${k}" should be registered in the companion group`,
+            );
           }
+          // The buttons should NOT also be injected into the tokens group.
+          assert.isUndefined(
+            controls.tokens.tools.progressTracks,
+            "companion tools should live in their own group, not tokens",
+          );
+        });
+
+        it("supports the v12 array-shaped controls (push a group)", async function () {
+          // v12: controls is an Array. The hook should push a group object
+          // rather than throw or silently drop the buttons.
+          const controls = [{ name: "tokens", tools: {} }];
+          Hooks.callAll("getSceneControlButtons", controls);
+          const group = controls.find(c => c?.name === "starforgedCompanion");
+          assert.isObject(group, "a companion group should be pushed onto the array");
+          assert.isTrue(
+            group.tools.progressTracks?.name === "progressTracks",
+            "the pushed group should carry the companion tools",
+          );
         });
       });
 

--- a/src/moves/burnMomentum.js
+++ b/src/moves/burnMomentum.js
@@ -31,6 +31,7 @@ import {
   canBurnMomentum,
   applyMomentumBurn,
   mapConsequences,
+  OUTCOME_RANK,
 } from "./resolver.js";
 import {
   getActor,
@@ -187,6 +188,17 @@ async function handleBurnClick(message, { narrate, persist, assemble }) {
   const burnResult = applyMomentumBurn(
     burn.momentum, burn.challengeDice, burn.markedImpactCount,
   );
+
+  // Defense-in-depth: never apply a burn that does not strictly improve the
+  // outcome, even if a stale card offered one. The render-time gate
+  // (canBurnMomentum in buildBurnState) should already prevent this, but a
+  // momentum change between render and click could leave a worsening burn on
+  // the card. Bail without touching meters or the card.
+  if (OUTCOME_RANK[burnResult.outcome] <= OUTCOME_RANK[burn.originalOutcome]) {
+    console.warn(`${MODULE_ID} | burnMomentum: burn would not improve ${burn.originalOutcome} → ${burnResult.outcome}; ignoring`);
+    return;
+  }
+
   const newConsequences = mapConsequences(burn.moveId, burnResult.outcome, burnResult.isMatch);
 
   await applyBurnMeterDeltas({

--- a/src/moves/burnMomentum.js
+++ b/src/moves/burnMomentum.js
@@ -89,6 +89,7 @@ export function buildBurnState(resolution, actor) {
     previewOutcome,
     originalApplied:    false,            // flipped to true once persistResolution writes
     actorId:            actor.id,
+    resolutionId:       resolution._id ?? null,  // links to the original narration card (F13a)
   };
 }
 
@@ -215,6 +216,13 @@ async function handleBurnClick(message, { narrate, persist, assemble }) {
     content: buildBurnedCardContent(message.content, burnResult, newConsequences),
   }).catch(err => console.warn(`${MODULE_ID} | burnMomentum: message.update failed:`, err));
 
+  // Supersede the original narration card (F13a): the burn changed the outcome,
+  // so the prose describing the pre-burn result is now stale. Strike it through
+  // and label it rather than delete it, so the history is preserved. The new
+  // (upgraded) narration is posted below by renarrate().
+  await supersedeOriginalNarration(burn).catch(err =>
+    console.warn(`${MODULE_ID} | burnMomentum: superseding original narration failed:`, err));
+
   // Re-narrate on the upgraded outcome. Best-effort — if the campaign has
   // no API key configured or the narrator is otherwise disabled, the move
   // card is still correctly updated above.
@@ -296,6 +304,46 @@ async function renarrate({ burn, burnResult, newConsequences, narrate, persist, 
 // ─────────────────────────────────────────────────────────────────────────────
 // CARD CONTENT REWRITE
 // ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Find the narration card posted for this resolution and mark it superseded
+ * (F13a). The burn changed the outcome, so the original prose no longer matches;
+ * we strike it through and add a note rather than deleting it. No-op when the
+ * card can't be found (e.g. narration was disabled).
+ *
+ * @param {Object} burn  the burn flag blob (carries resolutionId)
+ */
+export async function supersedeOriginalNarration(burn) {
+  const resolutionId = burn?.resolutionId;
+  if (!resolutionId) return;
+  const messages = globalThis.game?.messages?.contents ?? [];
+  const card = messages.find(m => {
+    const f = m?.flags?.[MODULE_ID];
+    return f?.narratorCard === true
+      && f?.resolutionId === resolutionId
+      && f?.burnSuperseded !== true;
+  });
+  if (!card) return;
+  await card.update({
+    [`flags.${MODULE_ID}.burnSuperseded`]: true,
+    content: buildSupersededNarrationContent(card.content),
+  });
+}
+
+/**
+ * Wrap a narration card's prose in a struck-through, dimmed block with a
+ * "superseded by momentum burn" note. Idempotent — re-applying is a no-op.
+ */
+export function buildSupersededNarrationContent(originalContent) {
+  const html = String(originalContent ?? "");
+  if (html.includes("sf-narration-superseded")) return html;
+  return html.replace(
+    /<div class="sf-narration-prose">([\s\S]*?)<\/div>/,
+    (_full, inner) =>
+      `<div class="sf-narration-prose sf-narration-superseded" style="opacity:0.55;text-decoration:line-through;"><s>${inner}</s></div>` +
+      `<div class="sf-narration-superseded-note" style="opacity:0.7;font-style:italic;">Superseded — momentum was burned to upgrade this outcome. See the updated narration below.</div>`,
+  );
+}
 
 /**
  * Rewrite the existing move-result card's HTML to reflect the burned

--- a/src/moves/resolver.js
+++ b/src/moves/resolver.js
@@ -130,8 +130,21 @@ export function canBurnMomentum(currentMomentum, currentOutcome, challengeDice, 
   if (currentOutcome === "strong_hit") return false;  // Already optimal
 
   const { outcome: burnedOutcome } = calcOutcome(currentMomentum, challengeDice);
-  return burnedOutcome !== currentOutcome;             // Only valid if it actually improves
+  // Only valid if it STRICTLY improves. A bare `!==` check would also offer a
+  // burn that makes the outcome worse — e.g. action score 7 (weak hit) but
+  // current momentum 6 burns down to a miss. Compare outcome rank instead.
+  return OUTCOME_RANK[burnedOutcome] > OUTCOME_RANK[currentOutcome];
 }
+
+/**
+ * Outcome severity ranking, worst → best. Used to decide whether a momentum
+ * burn (or any re-resolution) is an improvement. miss < weak_hit < strong_hit.
+ */
+export const OUTCOME_RANK = {
+  miss:       0,
+  weak_hit:   1,
+  strong_hit: 2,
+};
 
 /**
  * Apply momentum burn. Returns the new outcome after replacing action score

--- a/src/safety/sessionLifecycleDialogs.js
+++ b/src/safety/sessionLifecycleDialogs.js
@@ -189,6 +189,17 @@ async function postEndSessionCard({ questFocus, connectionFocus }) {
     await game.settings.set(MODULE_ID, "campaignState", state);
     Hooks.callAll(`${MODULE_ID}.sessionStateChanged`, { active: false });
 
+    // Write the session log on End (F18). writeSessionLog was implemented but
+    // never called from production, so the Session Log journal stayed blank.
+    if (game.settings.get(MODULE_ID, "sessionLogAutoWrite") !== false) {
+      try {
+        const { writeSessionLog } = await import("../world/worldJournal.js");
+        await writeSessionLog(state);
+      } catch (err) {
+        console.warn(`${MODULE_ID} | session log write failed:`, err?.message ?? err);
+      }
+    }
+
     if (questFocus || connectionFocus) {
       await applyMomentumToAllPlayers(1);
     }

--- a/src/sectors/sectorGenerator.js
+++ b/src/sectors/sectorGenerator.js
@@ -401,7 +401,9 @@ export async function generateNarratorStubs(sector, narratorSettings = {}) {
   const [sectorStubText, ...settlementResults] = await Promise.all([
     callStubApi(
       buildSectorStubPrompt(sector, regionLabel, settlementList, perspectiveNote),
-      150,
+      // ~110 words for a 2–3 sentence atmospheric paragraph. 150 tokens cut the
+      // prose off mid-sentence (F4); 320 lets the requested length complete.
+      320,
       apiKey
     ).catch(err => {
       console.warn(`${MODULE_ID} | sectorGenerator: sector stub generation failed:`, err);
@@ -410,7 +412,8 @@ export async function generateNarratorStubs(sector, narratorSettings = {}) {
     ...sector.settlements.map(s =>
       callStubApi(
         buildSettlementStubPrompt(s, sector, regionLabel, perspectiveNote),
-        100,
+        // 1–2 sentences; 100 tokens risked the same mid-sentence cut-off.
+        220,
         apiKey
       ).catch(err => {
         console.warn(`${MODULE_ID} | sectorGenerator: settlement stub generation failed for ${s.id}:`, err);
@@ -664,13 +667,40 @@ async function callStubApi(prompt, maxTokens, apiKey) {
     "anthropic-version": "2023-06-01",
   };
   const data = await apiPost(ANTHROPIC_URL, headers, body);
+  const stopReason = data.stop_reason;
   const text = (data.content ?? [])
     .filter(b => b.type === "text")
     .map(b => b.text)
     .join("");
   if (!text) throw new Error("Stub API returned no text");
-  return text.trim();
+  // If the model hit the token ceiling mid-sentence (F4), trim back to the last
+  // complete sentence so the prose never ends on a dangling clause. Only when
+  // truncated by length and a clean earlier sentence boundary exists.
+  return trimToLastSentence(text.trim(), stopReason === "max_tokens");
 }
+
+/**
+ * Trim text to its last complete sentence when it was cut off by the token
+ * limit and doesn't already end on terminal punctuation. Leaves naturally
+ * complete text untouched.
+ *
+ * @param {string} text
+ * @param {boolean} wasTruncated  true when stop_reason was "max_tokens"
+ * @returns {string}
+ */
+function trimToLastSentence(text, wasTruncated) {
+  if (!wasTruncated) return text;
+  if (/[.!?]["')\]]?\s*$/.test(text)) return text;       // already ends cleanly
+  // Find the last sentence-ending punctuation, then keep any immediately
+  // following closing quote/paren so dialogue like `"...end."` stays intact.
+  const m = /[.!?]["')\]]?/g;
+  let lastEnd = -1, match;
+  while ((match = m.exec(text)) !== null) lastEnd = match.index + match[0].length;
+  if (lastEnd <= 0) return text;                          // no earlier boundary — leave as-is
+  return text.slice(0, lastEnd).trim();
+}
+
+export { trimToLastSentence };
 
 function escapeHtml(str) {
   return String(str ?? "")

--- a/src/session/endSessionVignette.js
+++ b/src/session/endSessionVignette.js
@@ -24,6 +24,7 @@
 
 import { listConnections } from "../entities/connection.js";
 import { getActiveThreats } from "../world/worldJournal.js";
+import { stripMarkup } from "../audio/segments.js";
 
 const MODULE_ID = "starforged-companion";
 
@@ -166,7 +167,7 @@ export function buildEndSessionVignetteUserMessage(npc, campaignState) {
  */
 export async function postEndSessionVignetteCard({ text, npcName, sessionId = null }) {
   await globalThis.ChatMessage?.create?.({
-    content: `<div class="sf-session-vignette-card"><strong>Closing — ${escapeHtml(npcName)}</strong><p>${escapeHtml(text)}</p></div>`,
+    content: `<div class="sf-session-vignette-card"><strong>Closing — ${escapeHtml(npcName)}</strong><p>${escapeHtml(stripMarkup(text))}</p></div>`,
     flags:   {
       [MODULE_ID]: {
         sessionVignetteCard: true,

--- a/src/session/galleyVignette.js
+++ b/src/session/galleyVignette.js
@@ -23,6 +23,7 @@
  */
 
 import { readCharacterSnapshot } from "../character/actorBridge.js";
+import { stripMarkup } from "../audio/segments.js";
 
 const MODULE_ID = "starforged-companion";
 
@@ -140,7 +141,7 @@ function truncate(s, max) {
  */
 export async function postGalleyVignetteCard({ text, kind, sessionId = null }) {
   await globalThis.ChatMessage?.create?.({
-    content: `<div class="sf-session-vignette-card"><strong>Opening — Ship's Galley</strong><p>${escapeHtml(text)}</p></div>`,
+    content: `<div class="sf-session-vignette-card"><strong>Opening — Ship's Galley</strong><p>${escapeHtml(stripMarkup(text))}</p></div>`,
     flags:   {
       [MODULE_ID]: {
         sessionVignetteCard: true,

--- a/src/world/worldJournal.js
+++ b/src/world/worldJournal.js
@@ -761,20 +761,64 @@ function findPageByName(journal, pageName) {
 
 async function upsertPage(journal, pageName, flagKey, data) {
   const existing = findPageByName(journal, pageName);
+  const content  = renderPageBody(flagKey, data);
   if (existing) {
     await existing.setFlag(MODULE_ID, flagKey, data);
+    // Keep the visible page body in sync with the flag data (F15/F17/F19/F21:
+    // the description lived only in the flag, so the page rendered blank).
+    try {
+      await existing.update({ text: { format: 1, content } });
+    } catch (err) {
+      console.warn(`${MODULE_ID} | worldJournal: page body update for "${pageName}" failed:`, err);
+    }
     return existing;
   }
   try {
     const created = await journal.createEmbeddedDocuments("JournalEntryPage", [{
       name:  pageName,
       type:  "text",
+      text:  { format: 1, content },
       flags: { [MODULE_ID]: { [flagKey]: data } },
     }]);
     return Array.isArray(created) ? created[0] : created;
   } catch (err) {
     console.error(`${MODULE_ID} | worldJournal: upsertPage(${pageName}) failed:`, err);
     return null;
+  }
+}
+
+/**
+ * Render a World Journal entry's descriptive fields into HTML for the
+ * JournalEntryPage body. The entry data is also stored on a page flag (the
+ * panel reads that), but the page itself needs real body content or it renders
+ * blank — see F15/F17/F19/F21 in docs/testing/v1.6.1-playtest-findings.md.
+ *
+ * @param {string} flagKey  one of FLAG_KEYS.*
+ * @param {Object} data     the per-category entry record
+ * @returns {string} HTML
+ */
+function renderPageBody(flagKey, data) {
+  if (!data) return "";
+  const p = (s) => `<p>${escapeHtml(String(s))}</p>`;
+  const meta = (label, value) =>
+    value ? `<p><strong>${escapeHtml(label)}:</strong> ${escapeHtml(String(value))}</p>` : "";
+
+  switch (flagKey) {
+    case FLAG_KEYS.lore: {
+      const body = data.text || data.fact || "";
+      return (body ? p(body) : "") +
+        (data.confirmed ? "<p><em>Confirmed.</em></p>"
+         : data.narratorAsserted ? "<p><em>Pending confirmation.</em></p>" : "");
+    }
+    case FLAG_KEYS.threats:
+      return meta("Severity", data.severity) + (data.summary ? p(data.summary) : "");
+    case FLAG_KEYS.factions:
+      return meta("Attitude", data.attitude) + (data.knownGoal ? p(data.knownGoal) : "");
+    case FLAG_KEYS.locations:
+      return meta("Type", data.type) + meta("Status", data.status) +
+        (data.description ? p(data.description) : "");
+    default:
+      return data.summary ? p(data.summary) : (data.text ? p(data.text) : "");
   }
 }
 

--- a/tests/unit/audio.test.js
+++ b/tests/unit/audio.test.js
@@ -45,6 +45,8 @@ import {
 
 import {
   audioEnabledForThisClient,
+  claimAutoplayOnce,
+  _resetAutoplayGuardForTests,
 } from '../../src/audio/index.js';
 
 const MODULE_ID = 'starforged-companion';
@@ -631,5 +633,35 @@ describe('audioEnabledForThisClient', () => {
     game.settings._store.set(`${MODULE_ID}.audio.clientEnabled`, true);
     game.settings._store.set(`${MODULE_ID}.elevenLabsApiKey`, 'sk_xyz');
     expect(audioEnabledForThisClient()).toBe(true);
+  });
+});
+
+// F14: autoplay must fire at most once per card. A narrator card re-renders on
+// every message update (e.g. clicking its "Roll <move>" button), and the render
+// hook runs each time — without the once-guard, autoplay replayed the audio.
+describe('claimAutoplayOnce (F14)', () => {
+  beforeEach(() => _resetAutoplayGuardForTests());
+
+  it('returns true the first time and false on every re-render of the same card', () => {
+    expect(claimAutoplayOnce('card-A')).toBe(true);
+    expect(claimAutoplayOnce('card-A')).toBe(false);
+    expect(claimAutoplayOnce('card-A')).toBe(false);
+  });
+
+  it('tracks cards independently', () => {
+    expect(claimAutoplayOnce('card-A')).toBe(true);
+    expect(claimAutoplayOnce('card-B')).toBe(true);
+    expect(claimAutoplayOnce('card-A')).toBe(false);
+  });
+
+  it('returns false for a null/undefined card id', () => {
+    expect(claimAutoplayOnce(null)).toBe(false);
+    expect(claimAutoplayOnce(undefined)).toBe(false);
+  });
+
+  it('the reset helper clears the guard', () => {
+    expect(claimAutoplayOnce('card-A')).toBe(true);
+    _resetAutoplayGuardForTests();
+    expect(claimAutoplayOnce('card-A')).toBe(true);
   });
 });

--- a/tests/unit/audio.test.js
+++ b/tests/unit/audio.test.js
@@ -404,7 +404,10 @@ describe('PlaybackSession', () => {
     });
     expect(session.state).toBe(PLAYBACK_STATE.IDLE);
     const playPromise = session.play();
-    // Simulate Sound completion immediately
+    // Wait a tick so the segment's 'end' listener is attached (the sound is
+    // created and loaded asynchronously). Completion is driven by the 'end'
+    // event now, not by play()'s start-time resolution (F11).
+    await new Promise(r => setTimeout(r, 0));
     const sound = globalThis.foundry.audio.Sound._instances[0];
     sound._fire('end');
     await playPromise;
@@ -431,6 +434,36 @@ describe('PlaybackSession', () => {
       s._fire('end');
       await new Promise(r => setTimeout(r, 0));
     }
+    await playPromise;
+    expect(session.state).toBe(PLAYBACK_STATE.IDLE);
+  });
+
+  // F11 regression: the next segment must NOT begin until the current one's
+  // 'end' fires. Foundry v13 Sound.play() resolves at START; if completion were
+  // taken from that promise, both the narrator and NPC segments would be
+  // created and play on top of each other.
+  it('does not start the next segment until the current one ends (F11)', async () => {
+    const Sound = globalThis.foundry.audio.Sound;
+    Sound._reset();
+    const session = new PlaybackSession({
+      cardId: 'f11',
+      segments: [
+        { voice: 'narrator', src: '/a.mp3', text: 'a' },
+        { voice: 'npc',      src: '/b.mp3', text: 'b' },
+      ],
+    });
+    const playPromise = session.play();
+    await new Promise(r => setTimeout(r, 0));
+
+    // Only the FIRST segment's sound should exist; the second must wait.
+    expect(Sound._instances.length).toBe(1);
+
+    Sound._instances[0]._fire('end');           // first finishes
+    await new Promise(r => setTimeout(r, 0));
+
+    // Now — and only now — the second segment is created.
+    expect(Sound._instances.length).toBe(2);
+    Sound._instances[1]._fire('end');
     await playPromise;
     expect(session.state).toBe(PLAYBACK_STATE.IDLE);
   });

--- a/tests/unit/burnMomentum.test.js
+++ b/tests/unit/burnMomentum.test.js
@@ -9,7 +9,12 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { buildBurnState, renderBurnButtonHtml } from '../../src/moves/burnMomentum.js';
+import {
+  buildBurnState,
+  renderBurnButtonHtml,
+  buildSupersededNarrationContent,
+  supersedeOriginalNarration,
+} from '../../src/moves/burnMomentum.js';
 
 beforeEach(() => {
   game.actors._reset();
@@ -121,5 +126,66 @@ describe('renderBurnButtonHtml', () => {
     expect(html).toContain('data-action="sf-burn-momentum"');
     expect(html).toContain('8');
     expect(html).toContain('Strong Hit');
+  });
+});
+
+// F13a: burning momentum supersedes the original (now stale) narration card.
+describe('buildSupersededNarrationContent (F13a)', () => {
+  const card = (prose) =>
+    `<div class="sf-narration-card"><div class="sf-narration-label">◈ Narrator</div>` +
+    `<div class="sf-narration-prose">${prose}</div></div>`;
+
+  it('strikes through the prose and adds a superseded note', () => {
+    const out = buildSupersededNarrationContent(card('The door jams shut.'));
+    expect(out).toContain('sf-narration-superseded');
+    expect(out).toContain('<s>The door jams shut.</s>');
+    expect(out).toMatch(/Superseded/i);
+  });
+
+  it('is idempotent — re-applying does not double-wrap', () => {
+    const once  = buildSupersededNarrationContent(card('x'));
+    const twice = buildSupersededNarrationContent(once);
+    expect(twice).toBe(once);
+  });
+});
+
+describe('supersedeOriginalNarration (F13a)', () => {
+  const MODULE_ID = 'starforged-companion';
+
+  function fakeCard(resolutionId, extraFlags = {}) {
+    return {
+      content: '<div class="sf-narration-card"><div class="sf-narration-prose">stale prose</div></div>',
+      flags: { [MODULE_ID]: { narratorCard: true, resolutionId, ...extraFlags } },
+      updated: null,
+      async update(data) { this.updated = data; Object.assign(this, { content: data.content ?? this.content }); },
+    };
+  }
+
+  it('marks the matching narration card superseded', async () => {
+    const target = fakeCard('res-1');
+    const other  = fakeCard('res-2');
+    global.game.messages = { contents: [other, target] };
+
+    await supersedeOriginalNarration({ resolutionId: 'res-1' });
+
+    expect(target.updated).not.toBeNull();
+    expect(target.updated[`flags.${MODULE_ID}.burnSuperseded`]).toBe(true);
+    expect(target.updated.content).toContain('sf-narration-superseded');
+    expect(other.updated).toBeNull(); // untouched
+  });
+
+  it('is a no-op when no resolutionId or no match', async () => {
+    const card = fakeCard('res-9');
+    global.game.messages = { contents: [card] };
+    await supersedeOriginalNarration({ resolutionId: null });
+    await supersedeOriginalNarration({ resolutionId: 'nope' });
+    expect(card.updated).toBeNull();
+  });
+
+  it('skips a card already superseded', async () => {
+    const card = fakeCard('res-3', { burnSuperseded: true });
+    global.game.messages = { contents: [card] };
+    await supersedeOriginalNarration({ resolutionId: 'res-3' });
+    expect(card.updated).toBeNull();
   });
 });

--- a/tests/unit/entityPageBody.test.js
+++ b/tests/unit/entityPageBody.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { renderEntityBody as renderConnectionBody } from "../../src/entities/connection.js";
+import { renderEntityBody as renderFactionBody } from "../../src/entities/faction.js";
+import { renderEntityBody as renderCreatureBody } from "../../src/entities/creature.js";
+
+// F19 / theme T3: entity JournalEntryPages were created flag-only, so the page
+// rendered blank. The create paths now set text.content from renderEntityBody().
+// These pin the body renderers (the bodies are wired into createXxx()).
+
+describe("entity page body renderers (F19 / T3)", () => {
+  it("connection body carries the description and is non-empty", () => {
+    const html = renderConnectionBody({
+      name: "Vance",
+      role: "Crew member",
+      rank: "dangerous",
+      description: "Observant; notices discrepancies in cargo manifests.",
+    });
+    expect(html).toContain("Observant; notices discrepancies in cargo manifests.");
+    expect(html).toContain("Crew member");
+    expect(html).not.toBe("");
+  });
+
+  it("faction body carries the description", () => {
+    const html = renderFactionBody({
+      name: "Syndicate",
+      type: "guild",
+      description: "A smuggling cartel moving wartime munitions.",
+    });
+    expect(html).toContain("wartime munitions");
+  });
+
+  it("creature body carries the description", () => {
+    const html = renderCreatureBody({
+      name: "Forgespawn",
+      rank: "formidable",
+      description: "A writhing mass of repurposed hull plating.",
+    });
+    expect(html).toContain("repurposed hull plating");
+  });
+
+  it("escapes HTML in entity descriptions", () => {
+    const html = renderConnectionBody({ name: "X", description: "a <script> & b" });
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain("&amp;");
+    expect(html).not.toContain("<script>");
+  });
+
+  it("returns empty string for an entity with no descriptive fields", () => {
+    expect(renderConnectionBody({ name: "Bare" })).toBe("");
+    expect(renderFactionBody({})).toBe("");
+    expect(renderCreatureBody(null)).toBe("");
+  });
+});

--- a/tests/unit/resolver.test.js
+++ b/tests/unit/resolver.test.js
@@ -20,6 +20,7 @@ import {
   calcProgressOutcome,
   buildOutcomeLabel,
   canBurnMomentum,
+  OUTCOME_RANK,
   applyMomentumBurn,
   countMarkedImpacts,
   mapConsequences,
@@ -252,6 +253,26 @@ describe("canBurnMomentum", () => {
   it("returns false when momentum burn does not change the outcome", () => {
     // Momentum 3, challenge [5, 7] — 3 doesn't beat either → still a miss
     expect(canBurnMomentum(3, "miss", [5, 7], false)).toBe(false);
+  });
+
+  it("returns false when the burn would WORSEN the outcome (F12)", () => {
+    // The reported bug: action score 7 was a weak hit vs [6, 7], but current
+    // momentum is only 6. Burning to 6 beats neither die → miss. A bare
+    // `burnedOutcome !== currentOutcome` check offered this; the rank check
+    // must refuse it so weak_hit never burns down to miss.
+    expect(canBurnMomentum(6, "weak_hit", [6, 7], false)).toBe(false);
+  });
+
+  it("returns false when a weak hit would burn to another (non-improving) outcome", () => {
+    // Momentum equal to a die it doesn't beat — still not a strict improvement.
+    expect(canBurnMomentum(6, "weak_hit", [6, 9], false)).toBe(false);
+  });
+});
+
+describe("OUTCOME_RANK", () => {
+  it("orders outcomes miss < weak_hit < strong_hit", () => {
+    expect(OUTCOME_RANK.miss).toBeLessThan(OUTCOME_RANK.weak_hit);
+    expect(OUTCOME_RANK.weak_hit).toBeLessThan(OUTCOME_RANK.strong_hit);
   });
 });
 

--- a/tests/unit/sectorGenerator.test.js
+++ b/tests/unit/sectorGenerator.test.js
@@ -15,6 +15,7 @@ import {
   generateSector,
   rollTableResult,
   buildSettlementStubPrompt,
+  trimToLastSentence,
 } from "../../src/sectors/sectorGenerator.js";
 
 import { buildSectorBackgroundPrompt } from "../../src/sectors/sectorArt.js";
@@ -394,5 +395,33 @@ describe("buildSettlementStubPrompt", () => {
   it("uses provided perspective note", () => {
     const prompt = buildSettlementStubPrompt(settlement, sector, "Terminus", "Narrate in first person");
     expect(prompt).toContain("Narrate in first person");
+  });
+});
+
+// F4: sector narrative passages were cut off mid-sentence by the token cap.
+describe("trimToLastSentence (F4)", () => {
+  it("trims a length-truncated tail back to the last complete sentence", () => {
+    const cut = "The void hums with menace. The real question, as you chart your course through the cold black between them";
+    expect(trimToLastSentence(cut, true)).toBe("The void hums with menace.");
+  });
+
+  it("leaves naturally-complete text untouched even if truncated flag is set", () => {
+    const done = "A quiet sector. Nothing stirs here yet.";
+    expect(trimToLastSentence(done, true)).toBe(done);
+  });
+
+  it("never trims when the generation was not truncated", () => {
+    const ongoing = "An evocative fragment with no ending punctuation";
+    expect(trimToLastSentence(ongoing, false)).toBe(ongoing);
+  });
+
+  it("leaves text unchanged when there is no earlier sentence boundary", () => {
+    const oneClause = "A single dangling clause that never closes";
+    expect(trimToLastSentence(oneClause, true)).toBe(oneClause);
+  });
+
+  it("preserves a closing quote/paren after terminal punctuation", () => {
+    const quoted = '"We are not alone." She believed it, right up until the end';
+    expect(trimToLastSentence(quoted, true)).toBe('"We are not alone."');
   });
 });

--- a/tests/unit/segmentsDisplay.test.js
+++ b/tests/unit/segmentsDisplay.test.js
@@ -1,40 +1,24 @@
 import { describe, it, expect } from "vitest";
-import { stripMarkup, formatNpcDialogue } from "../../src/audio/segments.js";
+import { stripMarkup } from "../../src/audio/segments.js";
 
-// F9a / F22a regression: vignette (and main) cards must not leak <npc> markup,
-// and NPC dialogue should be styled. The vignette card builders now run
-// formatNpcDialogue(escapeHtml(stripMarkup(text))) — the same pipeline as the
-// main narrator card.
+// F9a / F22a regression: the session vignette cards (galley + closing) post
+// their prose via escapeHtml(stripMarkup(text)), so the audio voice-split
+// markers <npc>…</npc> must not survive into the rendered card.
 
-const escapeHtml = (s) =>
-  String(s)
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-
-describe("segments display pipeline (F9a)", () => {
-  it("stripMarkup removes <npc> tags but keeps the inner text", () => {
-    expect(stripMarkup('A <npc>"hi"</npc> B')).toBe('A "hi" B');
-  });
-
-  it("formatNpcDialogue wraps escaped quoted runs in a styled span", () => {
-    expect(formatNpcDialogue("a &quot;hello&quot; b")).toBe(
-      'a <span class="sf-npc-line">&quot;hello&quot;</span> b',
+describe("stripMarkup — vignette display (F9a / F22a)", () => {
+  it("removes <npc> tags but keeps the inner dialogue", () => {
+    expect(stripMarkup('He muttered <npc>"Paranoid,"</npc> to himself.')).toBe(
+      'He muttered "Paranoid," to himself.',
     );
   });
 
-  it("formatNpcDialogue tolerates empty / nullish input", () => {
-    expect(formatNpcDialogue("")).toBe("");
-    expect(formatNpcDialogue(undefined)).toBe("");
+  it("strips multiple tags and is case / newline insensitive", () => {
+    expect(stripMarkup('<npc>"A"</npc> x <NPC>"B"</NPC>')).toBe('"A" x "B"');
+    expect(stripMarkup("a <npc>line\nbreak</npc> b")).toBe("a line\nbreak b");
   });
 
-  it("full pipeline leaves no raw or escaped <npc> tags and styles the dialogue", () => {
-    const out = formatNpcDialogue(
-      escapeHtml(stripMarkup('He muttered <npc>"Paranoid,"</npc> to himself.')),
-    );
-    expect(out).not.toContain("<npc>");
-    expect(out).not.toContain("&lt;npc&gt;");
-    expect(out).toContain('<span class="sf-npc-line">&quot;Paranoid,&quot;</span>');
+  it("leaves tag-free prose unchanged and tolerates empty input", () => {
+    expect(stripMarkup("plain prose")).toBe("plain prose");
+    expect(stripMarkup("")).toBe("");
   });
 });

--- a/tests/unit/segmentsDisplay.test.js
+++ b/tests/unit/segmentsDisplay.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { stripMarkup, formatNpcDialogue } from "../../src/audio/segments.js";
+
+// F9a / F22a regression: vignette (and main) cards must not leak <npc> markup,
+// and NPC dialogue should be styled. The vignette card builders now run
+// formatNpcDialogue(escapeHtml(stripMarkup(text))) — the same pipeline as the
+// main narrator card.
+
+const escapeHtml = (s) =>
+  String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+
+describe("segments display pipeline (F9a)", () => {
+  it("stripMarkup removes <npc> tags but keeps the inner text", () => {
+    expect(stripMarkup('A <npc>"hi"</npc> B')).toBe('A "hi" B');
+  });
+
+  it("formatNpcDialogue wraps escaped quoted runs in a styled span", () => {
+    expect(formatNpcDialogue("a &quot;hello&quot; b")).toBe(
+      'a <span class="sf-npc-line">&quot;hello&quot;</span> b',
+    );
+  });
+
+  it("formatNpcDialogue tolerates empty / nullish input", () => {
+    expect(formatNpcDialogue("")).toBe("");
+    expect(formatNpcDialogue(undefined)).toBe("");
+  });
+
+  it("full pipeline leaves no raw or escaped <npc> tags and styles the dialogue", () => {
+    const out = formatNpcDialogue(
+      escapeHtml(stripMarkup('He muttered <npc>"Paranoid,"</npc> to himself.')),
+    );
+    expect(out).not.toContain("<npc>");
+    expect(out).not.toContain("&lt;npc&gt;");
+    expect(out).toContain('<span class="sf-npc-line">&quot;Paranoid,&quot;</span>');
+  });
+});

--- a/tests/unit/sessionVignetteCard.test.js
+++ b/tests/unit/sessionVignetteCard.test.js
@@ -1,0 +1,46 @@
+/**
+ * STARFORGED COMPANION
+ * tests/unit/sessionVignetteCard.test.js
+ *
+ * Regression for F9a / F22a: the session vignette cards must strip the
+ * `<npc>…</npc>` audio voice-split markup before posting to chat. The tags
+ * are an audio-pipeline concern (src/audio/segments.js) and must never render
+ * literally in the card. The inner NPC text is preserved verbatim.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { postGalleyVignetteCard } from '../../src/session/galleyVignette.js';
+import { postEndSessionVignetteCard } from '../../src/session/endSessionVignette.js';
+
+beforeEach(() => {
+  ChatMessage._reset();
+});
+
+const WITH_TAGS =
+  'Oakes leans in. <npc>Chen again, probably.</npc> She grins.';
+
+describe('session vignette cards strip <npc> markup (F9a / F22a)', () => {
+  it('galley (begin) card drops the tags but keeps the dialogue', async () => {
+    await postGalleyVignetteCard({ text: WITH_TAGS, kind: 'galley' });
+
+    const card = ChatMessage._created.at(-1);
+    expect(card.content).not.toContain('<npc>');
+    expect(card.content).not.toContain('npc>');
+    // inner NPC text survives verbatim
+    expect(card.content).toContain('Chen again, probably.');
+  });
+
+  it('end-session card drops the tags but keeps the dialogue', async () => {
+    await postEndSessionVignetteCard({
+      text: WITH_TAGS,
+      npcName: 'Evander Sato',
+    });
+
+    const card = ChatMessage._created.at(-1);
+    expect(card.content).not.toContain('<npc>');
+    expect(card.content).not.toContain('npc>');
+    expect(card.content).toContain('Chen again, probably.');
+    // the (markup-free) NPC name still renders in the heading
+    expect(card.content).toContain('Evander Sato');
+  });
+});

--- a/tests/unit/shipPortraitNotes.test.js
+++ b/tests/unit/shipPortraitNotes.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { withPortraitInNotes } from "../../src/art/generator.js";
+
+// F5: the generated ship portrait is mirrored into the starship Notes tab
+// (the sheet header icon is small). withPortraitInNotes prepends an <img>
+// block, idempotently, preserving the existing notes prose.
+
+describe("withPortraitInNotes (F5)", () => {
+  it("prepends an image block above the existing notes", () => {
+    const out = withPortraitInNotes("<p>A battered courier.</p>", "worlds/w/art/ship.png");
+    expect(out).toContain('<img src="worlds/w/art/ship.png"');
+    expect(out).toContain("<p>A battered courier.</p>");
+    expect(out.indexOf("<img")).toBeLessThan(out.indexOf("<p>A battered"));
+  });
+
+  it("is idempotent — regeneration replaces, not stacks, the art block", () => {
+    const once  = withPortraitInNotes("<p>notes</p>", "a.png");
+    const twice = withPortraitInNotes(once, "b.png");
+    const imgCount = (twice.match(/sf-ship-portrait/g) ?? []).length;
+    expect(imgCount).toBe(1);
+    expect(twice).toContain('src="b.png"');
+    expect(twice).not.toContain('src="a.png"');
+    expect(twice).toContain("<p>notes</p>");
+  });
+
+  it("strips the art block when given no path", () => {
+    const withArt = withPortraitInNotes("<p>notes</p>", "a.png");
+    const cleared = withPortraitInNotes(withArt, "");
+    expect(cleared).not.toContain("sf-ship-portrait");
+    expect(cleared).toContain("<p>notes</p>");
+  });
+
+  it("handles empty / nullish notes", () => {
+    expect(withPortraitInNotes("", "a.png")).toContain('<img src="a.png"');
+    expect(withPortraitInNotes(undefined, "a.png")).toContain('<img src="a.png"');
+  });
+});

--- a/tests/unit/worldJournal.test.js
+++ b/tests/unit/worldJournal.test.js
@@ -501,6 +501,14 @@ describe("writeSessionLog", () => {
     const journal = _journals.get(JOURNAL_NAMES.sessionLog);
     expect(journal.pages.contents).toHaveLength(1);
   });
+
+  // F18: the Session Log was blank because writeSessionLog was never called from
+  // production (now wired into End Session). Pin that the page carries a body.
+  it("writes a non-empty page body", async () => {
+    const page = await writeSessionLog(campaign({ sessionNumber: 3, currentSessionId: "ses-3" }));
+    expect(page.text?.content ?? "").not.toBe("");
+    expect(page.text.content).toContain("Session 3");
+  });
 });
 
 

--- a/tests/unit/worldJournal.test.js
+++ b/tests/unit/worldJournal.test.js
@@ -238,6 +238,59 @@ describe("recordThreat", () => {
   });
 });
 
+// F15/F17/F19/F21 (theme T3): the entry description must be written into the
+// JournalEntryPage BODY, not only the page flag, or the page renders blank.
+describe("page body content (T3)", () => {
+  const bodyOf = (journalName) =>
+    _journals.get(journalName)?.pages.contents.at(-1)?.text?.content ?? "";
+
+  it("lore page body carries the discovery text", async () => {
+    await recordLoreDiscovery(
+      "Airlock Cycling",
+      { text: "Someone is cycling through the airlock sequence.", narratorAsserted: true },
+      campaign(),
+    );
+    const body = bodyOf(JOURNAL_NAMES.lore);
+    expect(body).toContain("Someone is cycling through the airlock sequence.");
+    expect(body).not.toBe("");
+  });
+
+  it("threat page body carries severity + summary", async () => {
+    await recordThreat("Boarding Party", { severity: "active", summary: "cutting the seal" }, campaign());
+    const body = bodyOf(JOURNAL_NAMES.threats);
+    expect(body).toContain("cutting the seal");
+    expect(body).toContain("active");
+  });
+
+  it("faction page body carries attitude + known goal", async () => {
+    await recordFactionIntelligence(
+      "Syndicate",
+      { attitude: "hostile", knownGoal: "smuggle munitions" },
+      campaign(),
+    );
+    const body = bodyOf(JOURNAL_NAMES.factions);
+    expect(body).toContain("smuggle munitions");
+  });
+
+  it("location page body carries the description", async () => {
+    await recordLocation(
+      "Cargo Bay",
+      { type: "ship interior", description: "rows of unmarked cases" },
+      campaign(),
+    );
+    const body = bodyOf(JOURNAL_NAMES.locations);
+    expect(body).toContain("rows of unmarked cases");
+  });
+
+  it("updates the page body when an existing entry changes (update branch)", async () => {
+    await recordThreat("Drift", { severity: "looming", summary: "first" }, campaign());
+    await recordThreat("Drift", { severity: "active", summary: "second" }, campaign());
+    const body = bodyOf(JOURNAL_NAMES.threats);
+    expect(body).toContain("second");
+    expect(body).toContain("active");
+  });
+});
+
 
 // ─────────────────────────────────────────────────────────────────────────────
 // recordFactionIntelligence


### PR DESCRIPTION
## Initiating prompt

> Great! Please start fixing all observed issues

Fixes for the bugs recorded in `docs/testing/v1.6.1-playtest-findings.md` (logged on PR #144 during a fresh-world v1.6.1 playtest). One focused commit + regression test per fix; `npm test` and `npm run lint` green at every commit (1635 tests).

## Fixed in this PR

| Finding | Fix | Commit |
|---|---|---|
| **F12** (HIGH/mechanical) | Burn momentum can never worsen the outcome — `canBurnMomentum` uses a strict `OUTCOME_RANK` compare + click-time guard | `1dec481`, `a00b30c` |
| **F9a / F22a** | Strip `<npc>` voice-split tags from the begin/end vignette cards | `0feb3b4` |
| **T3 · F15/F17/F21** | World Journal pages render the entry description in the body (not just a flag) | `611214d` |
| **T3 · F19** | Connection/Faction/Creature entity pages render the description in the body | `892ea49` |
| **F11** | Audio segments play sequentially (completion on `end` event, not play-start) | `bf98c9e` |
| **F14** | Autoplay fires at most once per card (roll button no longer replays audio) | `7345a32` |
| **F4** | Sector narrator stubs no longer cut off mid-sentence (token budget + last-sentence trim) | `188c402` |
| **F18** | Session Log is written on End Session (`writeSessionLog` was implemented but never called) | `70caa5c` |
| **F13a** | Burn supersedes (strikes through) the stale original narration card before posting the upgraded one | `fd2d672` |
| **F16** | Companion gets its own top-level scene-control group (no longer hidden when switching groups) — ⚠️ see verification note | `03fdcf0` |
| **F5** | Generated ship portrait is mirrored (larger) into the Notes tab | `35a0bae` |

**F13b** (two cards' audio overlapping) was already covered by the existing `_claimActivePlayback` "latest-wins" logic; the real defects were F11 + F14, both fixed.

### ⚠️ Needs live-Foundry verification — F16
I can't run Foundry in this environment. F16 registers a dedicated scene-control group mirroring foundry-ironsworn's own pattern (`vendor/foundry-ironsworn/src/module/features/sceneButtons.ts`), wrapped defensively with a fallback to the tokens group so the buttons can't fully disappear. Please confirm in Foundry: the **"Starforged Companion"** group appears in the left toolbar, its buttons open their panels, and they stay reachable after selecting another control group.

## Not in this PR — design proposal to follow
The architectural/subjective themes are intentionally **not** coded here; a design proposal will be posted:
- **T1** — generate entity flavor/art/stubs *after* an entity is named + assigned, grounded in real sheet data (covers F3/F6/F7/F8/F9b).
- **T2** — raise the salience threshold for World Journal / Chronicle auto-capture; separate scene-transient from campaign-durable (covers F15-granularity/F17/F20/F21-granularity).

Findings F1, F2, F10, F22b were already resolved/working-as-intended (see the findings log).

https://claude.ai/code/session_01XZF59kAQPiExVT7fwkh2iP