### PR TITLE
fix(sectors): pre-register sector in campaignState so entities land in the named folder (F4)

### DIFF
--- a/src/sectors/sectorGenerator.js
+++ b/src/sectors/sectorGenerator.js
@@ -224,6 +224,20 @@ export function generateSectorName() {
 export async function createEntityJournals(sector, campaignState) {
   const settlements = {};
 
+  // Pre-register a minimal {id, name} stub for this sector in campaignState
+  // before any settlement is created. The actor-folder helpers
+  // (`getOrCreateSectorActorFolder` in src/entities/folder.js) resolve the
+  // per-sector Actor folder by walking `campaignState.sectors[]` for a
+  // matching id; without this stub, every settlement created here can't
+  // resolve its sector name and falls back to the shared `Sectors / Unsorted`
+  // folder (F4). storeSector() later replaces this stub with the full
+  // sector record — the stub just keeps the folder lookup alive during
+  // entity creation. Idempotent so re-runs don't double-register.
+  campaignState.sectors ??= [];
+  if (!campaignState.sectors.some(s => s?.id === sector.id)) {
+    campaignState.sectors.push({ id: sector.id, name: sector.name });
+  }
+
   // persist:false on the entity creators — storeSector (the only caller of
   // this function in production) performs a single batched game.settings.set
   // at the end. Multiple sequential writes against the same campaignState
@@ -346,7 +360,12 @@ export async function storeSector(sector, extras, campaignState) {
   // Defensive init — Quench test mock predates these fields in CampaignStateSchema.
   campaignState.sectors     ??= [];
   campaignState.locationIds ??= [];
-  campaignState.sectors.push(stored);
+  // createEntityJournals pre-registers a {id, name} stub so the actor-folder
+  // helpers can resolve the per-sector folder before any settlement is
+  // created (F4). Replace that stub in-place rather than push-and-duplicate.
+  const stubIdx = campaignState.sectors.findIndex(s => s?.id === stored.id);
+  if (stubIdx >= 0) campaignState.sectors[stubIdx] = stored;
+  else              campaignState.sectors.push(stored);
   campaignState.activeSectorId = stored.id;
 
   // §3.5: saveSectorToJournal removed — no production code read the

--- a/tests/unit/sectorGenerator.test.js
+++ b/tests/unit/sectorGenerator.test.js
@@ -18,6 +18,8 @@ import {
   buildSettlementStubPrompt,
   trimToLastSentence,
   applyStubsToSettlementEntities,
+  createEntityJournals,
+  storeSector,
 } from "../../src/sectors/sectorGenerator.js";
 import * as settlement from "../../src/entities/settlement.js";
 
@@ -25,6 +27,7 @@ import { buildSectorBackgroundPrompt } from "../../src/sectors/sectorArt.js";
 import { SECTOR_TROUBLE } from "../../src/oracles/tables/misc.js";
 import { ROLE, GOAL, FAMILY_NAMES } from "../../src/oracles/tables/characters.js";
 import { ACTION, THEME } from "../../src/oracles/tables/core.js";
+import { _resetFolderCache } from "../../src/entities/folder.js";
 
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -541,5 +544,86 @@ describe("applyStubsToSettlementEntities", () => {
       { settlements: { gen1: "fails", gen2: "succeeds" } },
     )).resolves.toBeUndefined();
     expect(spy).toHaveBeenCalledTimes(2);
+  });
+});
+
+
+// ─────────────────────────────────────────────────────────────────────────────
+// F4 — sector-folder routing. createEntityJournals must pre-register the
+// sector in campaignState.sectors before any settlement is created, so the
+// per-sector Actor folder helpers (`getOrCreateSectorActorFolder`) resolve
+// `Sectors / <Sector Name>` instead of falling back to `Sectors / Unsorted`.
+// Without this stub, every sector-spawned settlement lands in Unsorted.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("createEntityJournals — F4 sector-folder pre-registration", () => {
+  beforeEach(() => {
+    if (global.game?.folders?._reset) global.game.folders._reset();
+    if (global.game?.actors?._reset)  global.game.actors._reset();
+    _resetFolderCache();
+  });
+
+  it("adds a {id, name} sector stub to campaignState.sectors before any settlement is created", async () => {
+    const sector = {
+      id:   "sector-test-001",
+      name: "Delphian Anvil",
+      settlements: [],
+      connection: { id: "c-1", name: "Amelia Stark", role: "Scholar", goal: "Collect a debt", aspect: "Calm", firstLook: ["Bookish"], homeSettlement: "the sector" },
+    };
+    const campaignState = { sectors: [], settlementIds: [], connectionIds: [] };
+
+    await createEntityJournals(sector, campaignState);
+
+    const stub = campaignState.sectors.find(s => s.id === sector.id);
+    expect(stub).toBeDefined();
+    expect(stub.name).toBe("Delphian Anvil");
+  });
+
+  it("is idempotent — running twice does not duplicate the sector record", async () => {
+    const sector = {
+      id:   "sector-test-002",
+      name: "Sulaco Arch",
+      settlements: [],
+      connection: { id: "c-2", name: "Mira Vega", role: "Pilot", goal: "Find a person", aspect: "Aloof", firstLook: ["Scarred"], homeSettlement: "the sector" },
+    };
+    const campaignState = { sectors: [], settlementIds: [], connectionIds: [] };
+
+    await createEntityJournals(sector, campaignState);
+    await createEntityJournals(sector, campaignState);
+
+    const matches = campaignState.sectors.filter(s => s.id === sector.id);
+    expect(matches).toHaveLength(1);
+  });
+
+  it("storeSector replaces the pre-registered stub in place rather than appending a second copy", async () => {
+    const sector = {
+      id:        "sector-test-003",
+      name:      "Devil's Maw",
+      region:    "terminus",
+      regionLabel: "Terminus",
+      trouble:   "Pirates",
+      faction:   null,
+      settlements: [],
+      createdAt: new Date().toISOString(),
+      mapData:   { sectorId: "sector-test-003", gridWidth: 10, gridHeight: 8, settlements: [], passages: [], discoveries: [] },
+      connection: { id: "c-3", name: "Kael Volkov", role: "Smuggler", goal: "Gain riches", aspect: "Bold", firstLook: ["Scarred"], homeSettlement: "the sector" },
+    };
+    const campaignState = { sectors: [], settlementIds: [], connectionIds: [] };
+
+    // Step 1: createEntityJournals pre-registers a stub
+    await createEntityJournals(sector, campaignState);
+    expect(campaignState.sectors).toHaveLength(1);
+    const stub = campaignState.sectors[0];
+    expect(stub.name).toBe("Devil's Maw");
+    // The stub is a minimal {id, name} — no trouble / region / mapData yet.
+    expect(stub.trouble).toBeUndefined();
+
+    // Step 2: storeSector lands the full record and replaces the stub
+    await storeSector(sector, { settlements: {}, connectionJournalId: null }, campaignState);
+    expect(campaignState.sectors).toHaveLength(1);
+    const stored = campaignState.sectors[0];
+    expect(stored.id).toBe("sector-test-003");
+    expect(stored.trouble).toBe("Pirates");
+    expect(stored.region).toBe("terminus");
   });
 });


### PR DESCRIPTION
## Initiating prompt

> sectors entities are falling under "unsorted" rather than the sector names

(Screenshot attached: the Actor sidebar showing `Sectors > Unsorted` with all five settlements — `Evenfall`, `Hearth`, `Hyperion`, `Lagrange`, `Moirai` — from the `Delphian Anvil` sector landing under the `Unsorted` fallback rather than under a `Delphian Anvil` subfolder. F4 of the v1.7.0 playtest findings catalog.)

## Summary

Sector-created entities (settlements / planets / locations) were landing in a generic `Sectors / Unsorted` Actor folder instead of the per-sector `Sectors / <Sector Name>` folder. The Entity → Actor migration scope designed for the per-sector layout; this regression undid it for every new sector.

**Root cause**: ordering bug between `createEntityJournals` and `storeSector` in `src/sectors/sectorGenerator.js`. The per-entity creators (`createSettlement` / `createPlanet` / `createLocation`) call into `getOrCreateSectorActorFolder` (`src/entities/folder.js`), which resolves the sector's folder name by walking `campaignState.sectors[].name` for a matching `id`. At creation time the sector hadn't been pushed onto `campaignState.sectors` yet — that happens in `storeSector`, which runs *after* `createEntityJournals` per the orchestration in `sectorPanel.js`. The folder helper fell through to its `Sectors / Unsorted` fallback every time, accumulating every new sector's entities in the same generic bucket.

**Fix**: `createEntityJournals` now pre-registers a minimal `{ id, name }` sector stub on `campaignState.sectors[]` **before** any entity creator runs, so the folder lookup resolves to the right name. The stub is idempotent (skips if a record with the same id already exists). `storeSector` locates the stub by id and replaces it in place with the full sector record, rather than appending a second copy — so the sector list stays de-duplicated as it transitions from "stub during creation" to "complete record after storage".

## Coverage

- **3 new unit tests** in `tests/unit/sectorGenerator.test.js`:
  - Pre-registration creates a `{id, name}` stub before any settlement is created.
  - Re-running `createEntityJournals` against the same sector doesn't double-register.
  - `storeSector` replaces the stub in place (one entry, full record).
- Existing 1722 tests still pass (1725 with the new ones); lint clean.

## Out of scope

**Cleanup of entities already in `Sectors / Unsorted` from prior runs** is not handled by this PR. Those are persisted Actor folder assignments, not generation-time artefacts. Users can drag the misplaced Actors to the right folder by hand, or a follow-up migrator can reparent them. The CHANGELOG entry calls this out.

## Files changed

- `src/sectors/sectorGenerator.js` — pre-register stub in `createEntityJournals`; in-place replace in `storeSector`.
- `tests/unit/sectorGenerator.test.js` — F4 describe block with three pinning tests.
- `CHANGELOG.md` — `[Unreleased]` entry; reconciled the previously-`[Unreleased]` Private Channel bullet under the live `[1.7.0]` heading (same reconciliation as #149 / #150 / #151).
- `src/help/helpJournal.js` — `CONTENT_VERSION` → `1.7.1`; plain-language v1.7.1 changelog block.

## Test plan

- [x] `npm test` — 1725/1725 pass.
- [x] `npm run lint` — clean.
- [ ] **Live verify on Forge** — open a fresh world, run the Sector Creator wizard, confirm the generated settlements land in `Sectors / <Sector Name>` (the sector's own folder) rather than `Sectors / Unsorted`. Re-run the wizard with a second sector to verify each gets its own folder.

## Catalog

F4 of the v1.7.0 playtest findings.

https://claude.ai/code/session_01Syjhqwk5xgL5fAeW28vPsj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Syjhqwk5xgL5fAeW28vPsj)_