### PR TITLE
fix(sheets): rolled data → foundry-ironsworn sheet fields (F3 / F6 / F7 / F17 — Tier 2)

### DIFF
--- a/src/entities/connection.js
+++ b/src/entities/connection.js
@@ -482,6 +482,7 @@ export function renderEntityBody(connection) {
   meta("Rank", connection?.rank);
   meta("Relationship", connection?.relationshipType);
   if (connection?.description) out.push(`<p>${esc(connection.description)}</p>`);
+  meta("Goal", connection?.goal);
   if (connection?.motivation)  out.push(`<p><strong>Motivation:</strong> ${esc(connection.motivation)}</p>`);
   if (connection?.notes)       out.push(`<p>${esc(connection.notes)}</p>`);
   return out.join("");

--- a/src/entities/planet.js
+++ b/src/entities/planet.js
@@ -30,6 +30,35 @@ import {
 const MODULE_ID = "starforged-companion";
 const FLAG_KEY  = "planet";
 
+// foundry-ironsworn LocationModel.klass for subtype=planet is one of the
+// canonical Starforged planet classes (lowercase, no "World" suffix). We roll
+// "Desert World" / "Vital World" / etc. — without normalisation the sheet's
+// "Type of planet" dropdown can't match and renders blank (F6).
+const PLANET_KLASS_MAP = {
+  "desert":    "desert",
+  "furnace":   "furnace",
+  "grave":     "grave",
+  "ice":       "ice",
+  "jovian":    "jovian",
+  "jungle":    "jungle",
+  "ocean":     "ocean",
+  "rocky":     "rocky",
+  "shattered": "shattered",
+  "tainted":   "tainted",
+  "vital":     "vital",
+};
+
+/**
+ * @param {string|null} raw — accepts "Desert World", "desert", "DESERT", …
+ * @returns {string|null} canonical lowercase klass, or null when no match.
+ */
+function normalisePlanetKlass(raw) {
+  if (!raw) return null;
+  // Strip trailing "world" so "Desert World" / "desert world" both map.
+  const key = String(raw).trim().toLowerCase().replace(/\s+world$/, "");
+  return PLANET_KLASS_MAP[key] ?? null;
+}
+
 export const PlanetSchema = {
   _id:    "",
   name:   "",
@@ -97,7 +126,7 @@ export async function createPlanet(data, campaignState, { persist = true } = {})
     folder: folderId,
     system: {
       subtype:     "planet",
-      klass:       planet.type ?? null,
+      klass:       normalisePlanetKlass(planet.type),
       description: planet.description ?? "",
     },
     flags:  {
@@ -147,7 +176,7 @@ export async function updatePlanet(actorId, updates) {
 
   // Mirror native fields onto the Actor document so the system sheet renders.
   const systemPatch = {};
-  if (updates.type !== undefined)        systemPatch["system.klass"]       = updated.type ?? null;
+  if (updates.type !== undefined)        systemPatch["system.klass"]       = normalisePlanetKlass(updated.type);
   if (updates.description !== undefined) systemPatch["system.description"] = updated.description ?? "";
   if (Object.keys(systemPatch).length) await document.update(systemPatch);
 

--- a/src/entities/settlement.js
+++ b/src/entities/settlement.js
@@ -33,6 +33,26 @@ import {
 const MODULE_ID = "starforged-companion";
 const FLAG_KEY  = "settlement";
 
+// foundry-ironsworn LocationModel.klass for subtype=settlement is one of
+// `planetside` | `orbital` | `deep space` (lowercase, single space). We roll
+// Planetside / Orbital / Deep Space (titlecase) — without normalisation the
+// sheet's "Type of settlement" dropdown can't match and renders blank (F6).
+const SETTLEMENT_KLASS_MAP = {
+  "planetside": "planetside",
+  "orbital":    "orbital",
+  "deep space": "deep space",
+};
+
+/**
+ * @param {string|null} raw — titlecase, mixed-case, or already-canonical value.
+ * @returns {string|null} canonical lowercase klass, or null when no match.
+ */
+function normaliseSettlementKlass(raw) {
+  if (!raw) return null;
+  const key = String(raw).trim().toLowerCase();
+  return SETTLEMENT_KLASS_MAP[key] ?? null;
+}
+
 export const SettlementSchema = {
   _id:      "",
   name:     "",
@@ -46,6 +66,9 @@ export const SettlementSchema = {
   authority:      "",
   projects:       [],
   trouble:        "",
+  stellar:        "",    // Stellar object rolled once per sector and shared across all
+                         // settlements/planets in the sector (F7). Surfaces on the description
+                         // body and drives the scene-map stellar pin.
 
   // Narrative
   description: "",
@@ -113,7 +136,7 @@ export async function createSettlement(data, campaignState, { persist = true } =
     folder: folderId,
     system: {
       subtype:     "settlement",
-      klass:       settlement.location ?? null,
+      klass:       normaliseSettlementKlass(settlement.location),
       description: settlement.description ?? "",
     },
     flags:  {
@@ -163,7 +186,7 @@ export async function updateSettlement(actorId, updates) {
   };
 
   const systemPatch = {};
-  if (updates.location !== undefined)    systemPatch["system.klass"]       = updated.location ?? null;
+  if (updates.location !== undefined)    systemPatch["system.klass"]       = normaliseSettlementKlass(updated.location);
   if (updates.description !== undefined) systemPatch["system.description"] = updated.description ?? "";
   if (Object.keys(systemPatch).length) await document.update(systemPatch);
 

--- a/src/integration/quench.js
+++ b/src/integration/quench.js
@@ -8099,9 +8099,12 @@ function registerLocationFamilyActorWiresTests(quench) {
             type:        "Vital",
           },
           extraSystemAssertion: (actor) => {
-            // planet.js writes planet.type → actor.system.klass.
-            assert.equal(actor.system?.klass, "Vital",
-              "planet writer should map data.type → actor.system.klass");
+            // planet.js writes planet.type → actor.system.klass after
+            // normalising to the foundry-ironsworn enum's canonical lowercase
+            // short form (F6: "Vital World"/"Vital" → "vital"; titlecase
+            // values leave the sheet's "Type of planet" dropdown blank).
+            assert.equal(actor.system?.klass, "vital",
+              "planet writer should map data.type → actor.system.klass (lowercase per F6)");
           },
         },
         {
@@ -8117,8 +8120,11 @@ function registerLocationFamilyActorWiresTests(quench) {
           },
           extraSystemAssertion: (actor) => {
             // settlement.js writes settlement.location → actor.system.klass.
-            assert.equal(actor.system?.klass, "Orbital",
-              "settlement writer should map data.location → actor.system.klass");
+            // settlement.js normalises to the foundry-ironsworn enum
+            // (F6: "Orbital" → "orbital"); titlecase leaves the sheet's
+            // "Type of settlement" dropdown blank.
+            assert.equal(actor.system?.klass, "orbital",
+              "settlement writer should map data.location → actor.system.klass (lowercase per F6)");
           },
         },
         {

--- a/src/schemas.js
+++ b/src/schemas.js
@@ -386,6 +386,10 @@ export const ConnectionSchema = {
   description: "",              // Physical description
   background: "",               // Known history
   motivation: "",               // What drives them (may be blank — unknown)
+  goal: "",                     // CHARACTERS.GOAL oracle result — the driving objective
+                                // rolled at creation (sector wizard / Make a Connection).
+                                // F3: rolled by sector creator and passed to createConnection
+                                // but had no schema home, so it never reached the journal body.
   secrets: "",                  // Information hidden from the player character (GM only)
 
   // Append-only relationship history log

--- a/src/sectors/sectorGenerator.js
+++ b/src/sectors/sectorGenerator.js
@@ -67,10 +67,18 @@ export function generateSector(region, _overrides = {}) {
   const cfg = REGION_CONFIG[region];
   if (!cfg) throw new Error(`Unknown region: ${region}`);
 
-  // Steps 3–5: Generate each settlement
+  // Step 1: Stellar object — rolled once per sector and shared across all
+  // settlements / planets in that sector (F7). Drives the scene-map stellar
+  // pin (sceneBuilder.js → iconForStellarObject) which was already wired up
+  // but starved of data because nothing populated this field.
+  const stellar = rollTableResult(SPACE.STELLAR_OBJECT);
+
+  // Steps 3–5: Generate each settlement, sharing the sector's stellar object.
   const settlements = [];
   for (let i = 0; i < cfg.settlements; i++) {
-    settlements.push(generateSettlement(region));
+    const s = generateSettlement(region);
+    s.stellar = stellar;
+    settlements.push(s);
   }
 
   // Step 10: Sector trouble
@@ -253,6 +261,7 @@ export async function createEntityJournals(sector, campaignState) {
       projects:   s.projects,
       trouble:    s.trouble ?? null,
       planet:     s.planet ?? null,
+      stellar:    s.stellar ?? null,
       sectorId:   sector.id,
     }, campaignState, { persist: false });
     const actorId = campaignState.settlementIds?.[beforeLen] ?? null;
@@ -471,11 +480,47 @@ export async function applyStubsToSettlementEntities(settlements, stubs) {
     const stub = stubs.settlements[sourceId];
     if (!stub || !actor?.id) continue;
     try {
-      await updateSettlement(actor.id, { description: stub });
+      // F17: combine the narrator prose with a structured rolled-detail block
+      // so the sheet displays both the atmospheric description AND the
+      // Population/Authority/Projects/Trouble that the wizard rolled.
+      const data = actor.flags?.[MODULE_ID]?.settlement ?? {};
+      const description = composeSettlementDescription(stub, data);
+      await updateSettlement(actor.id, { description });
     } catch (err) {
       console.warn(`${MODULE_ID} | Sector: could not write stub to settlement Actor:`, err.message);
     }
   }
+}
+
+/**
+ * Build the settlement-sheet description body: narrator prose first, then a
+ * compact, dot-separated facts line carrying every rolled oracle result. The
+ * foundry-ironsworn Location-actor schema only exposes `subtype`/`klass`/
+ * `description` — there's no `system.population` / `system.authority` /
+ * etc. — so the rolled details either ride in the description HTML or stay
+ * invisible to the sheet (F17).
+ *
+ * @param {string} prose       — narrator-generated atmospheric prose, HTML or plain.
+ * @param {Object} data        — settlement payload (matches SettlementSchema).
+ * @returns {string} description HTML.
+ */
+export function composeSettlementDescription(prose, data = {}) {
+  const esc = (s) => String(s ?? "")
+    .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  const parts = [];
+  if (data.location)            parts.push(`<strong>Location:</strong> ${esc(data.location)}`);
+  if (data.population)          parts.push(`<strong>Population:</strong> ${esc(data.population)}`);
+  if (data.authority)           parts.push(`<strong>Authority:</strong> ${esc(data.authority)}`);
+  if (data.projects?.length)    parts.push(`<strong>Projects:</strong> ${data.projects.map(esc).join(", ")}`);
+  if (data.trouble)             parts.push(`<strong>Trouble:</strong> ${esc(data.trouble)}`);
+  if (data.firstLook)           parts.push(`<strong>First look:</strong> ${esc(data.firstLook)}`);
+  if (data.initialContact)      parts.push(`<strong>Initial contact:</strong> ${esc(data.initialContact)}`);
+  if (data.stellar)             parts.push(`<strong>Stellar object:</strong> ${esc(data.stellar)}`);
+
+  const proseHtml  = prose ? (prose.trim().startsWith("<") ? prose : `<p>${esc(prose)}</p>`) : "";
+  const factsHtml  = parts.length ? `<p>${parts.join(" &middot; ")}</p>` : "";
+  if (proseHtml && factsHtml) return `${proseHtml}<hr>${factsHtml}`;
+  return proseHtml || factsHtml;
 }
 
 /**

--- a/tests/unit/entityLocationFamilyActor.test.js
+++ b/tests/unit/entityLocationFamilyActor.test.js
@@ -32,7 +32,10 @@ describe("createSettlement", () => {
     const actor = global.game.actors.contents[0];
     expect(actor.type).toBe("location");
     expect(actor.system.subtype).toBe("settlement");
-    expect(actor.system.klass).toBe("Planetside");
+    // F6: klass must be lowercase to match the foundry-ironsworn enum
+    // (`planetside` | `orbital` | `deep space`). Titlecase leaves the sheet's
+    // "Type of settlement" dropdown blank.
+    expect(actor.system.klass).toBe("planetside");
     expect(actor.flags[MODULE].settlement.name).toBe("Bleakhold");
     expect(actor.flags[MODULE].settlement.sectorId).toBe("sec-1");
     expect(state.settlementIds).toEqual([actor.id]);
@@ -66,7 +69,7 @@ describe("createSettlement", () => {
     await updateSettlement(id, { name: "New", location: "Orbital" });
     const actor = global.game.actors.get(id);
     expect(actor.name).toBe("New");
-    expect(actor.system.klass).toBe("Orbital");
+    expect(actor.system.klass).toBe("orbital");
     expect(getSettlement(id).location).toBe("Orbital");
   });
 
@@ -84,7 +87,10 @@ describe("createPlanet", () => {
     await createPlanet({ name: "Cinderworld", type: "Furnace World" }, state);
     const actor = global.game.actors.contents[0];
     expect(actor.system.subtype).toBe("planet");
-    expect(actor.system.klass).toBe("Furnace World");
+    // F6: klass must be the canonical lowercase short form ("furnace"),
+    // not the oracle's display string ("Furnace World"). Otherwise the
+    // sheet's "Type of planet" dropdown can't match.
+    expect(actor.system.klass).toBe("furnace");
     expect(actor.flags[MODULE].planet.name).toBe("Cinderworld");
     expect(state.planetIds).toEqual([actor.id]);
   });

--- a/tests/unit/entityPageBody.test.js
+++ b/tests/unit/entityPageBody.test.js
@@ -50,4 +50,25 @@ describe("entity page body renderers (F19 / T3)", () => {
     expect(renderFactionBody({})).toBe("");
     expect(renderCreatureBody(null)).toBe("");
   });
+
+  it("connection body surfaces the rolled Goal (F3)", () => {
+    // Goal is rolled by the sector wizard / Make a Connection and passed
+    // to createConnection, but before F3 it had no schema home and never
+    // appeared on the journal-page body.
+    const html = renderConnectionBody({
+      name: "Amelia Stark",
+      role: "Scholar",
+      goal: "Collect a debt",
+      description: "Bookish, terse, intense eye contact.",
+    });
+    expect(html).toContain("<strong>Goal:</strong> Collect a debt");
+    expect(html).toContain("Scholar");
+    expect(html).toContain("Bookish, terse, intense eye contact.");
+  });
+
+  it("connection body omits Goal when it is missing/empty", () => {
+    const html = renderConnectionBody({ name: "X", role: "Scout" });
+    expect(html).toContain("Scout");
+    expect(html).not.toContain("<strong>Goal:</strong>");
+  });
 });

--- a/tests/unit/sectorGenerator.test.js
+++ b/tests/unit/sectorGenerator.test.js
@@ -508,25 +508,42 @@ describe("trimToLastSentence (F4)", () => {
 describe("applyStubsToSettlementEntities", () => {
   afterEach(() => { vi.restoreAllMocks(); });
 
-  it("routes each stub through updateSettlement keyed by actor id", async () => {
+  it("routes each stub through updateSettlement keyed by actor id (description includes narrator prose)", async () => {
     const spy = vi.spyOn(settlement, "updateSettlement").mockResolvedValue({});
+    // Actors carry the settlement flag (empty payload here — composeSettlementDescription
+    // tolerates missing rolled details and renders prose-only).
+    const a1 = { id: "actor-1", flags: { "starforged-companion": { settlement: {} } } };
+    const a2 = { id: "actor-2", flags: { "starforged-companion": { settlement: {} } } };
     await applyStubsToSettlementEntities(
-      { gen1: { id: "actor-1" }, gen2: { id: "actor-2" } },
+      { gen1: a1, gen2: a2 },
       { settlements: { gen1: "A windswept dome.", gen2: "A rusting orbital." } },
     );
     expect(spy).toHaveBeenCalledTimes(2);
-    expect(spy).toHaveBeenCalledWith("actor-1", expect.objectContaining({ description: "A windswept dome." }));
-    expect(spy).toHaveBeenCalledWith("actor-2", expect.objectContaining({ description: "A rusting orbital." }));
+    // F17: applyStubsToSettlementEntities now composes a description that
+    // pairs the narrator stub with a structured rolled-detail block. The
+    // exact HTML is asserted in the composeSettlementDescription tests
+    // below — here we just pin that each call's description contains the
+    // original prose so the narrator stub still drives the body.
+    expect(spy).toHaveBeenCalledWith("actor-1", expect.objectContaining({
+      description: expect.stringContaining("A windswept dome."),
+    }));
+    expect(spy).toHaveBeenCalledWith("actor-2", expect.objectContaining({
+      description: expect.stringContaining("A rusting orbital."),
+    }));
   });
 
   it("skips settlements with no stub, an empty stub, or a missing actor", async () => {
     const spy = vi.spyOn(settlement, "updateSettlement").mockResolvedValue({});
+    const a1 = { id: "actor-1", flags: { "starforged-companion": { settlement: {} } } };
+    const a3 = { id: "actor-3", flags: { "starforged-companion": { settlement: {} } } };
     await applyStubsToSettlementEntities(
-      { gen1: { id: "actor-1" }, gen2: null, gen3: { id: "actor-3" } },
+      { gen1: a1, gen2: null, gen3: a3 },
       { settlements: { gen1: "Only this one.", gen3: "" } }, // gen2 actor null, gen3 stub empty
     );
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith("actor-1", expect.objectContaining({ description: "Only this one." }));
+    expect(spy).toHaveBeenCalledWith("actor-1", expect.objectContaining({
+      description: expect.stringContaining("Only this one."),
+    }));
   });
 
   it("no-ops when the stubs payload has no settlements", async () => {
@@ -548,6 +565,7 @@ describe("applyStubsToSettlementEntities", () => {
 });
 
 
+// ─────────────────────────────────────────────────────────────────────────────
 // ─────────────────────────────────────────────────────────────────────────────
 // F4 — sector-folder routing. createEntityJournals must pre-register the
 // sector in campaignState.sectors before any settlement is created, so the
@@ -625,5 +643,76 @@ describe("createEntityJournals — F4 sector-folder pre-registration", () => {
     expect(stored.id).toBe("sector-test-003");
     expect(stored.trouble).toBe("Pirates");
     expect(stored.region).toBe("terminus");
+  });
+});
+
+
+// ─────────────────────────────────────────────────────────────────────────────
+// composeSettlementDescription (F17 — rolled-detail block on the sheet body)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("composeSettlementDescription", () => {
+  let composeSettlementDescription;
+  beforeAll(async () => {
+    ({ composeSettlementDescription } = await import("../../src/sectors/sectorGenerator.js"));
+  });
+
+  it("pairs narrator prose with a dot-separated facts line of rolled details", () => {
+    const out = composeSettlementDescription(
+      "<p>You arrive at a windswept dome.</p>",
+      { location: "Planetside", population: "Few", authority: "Fair", projects: ["Raiding"], trouble: "Pirates" },
+    );
+    expect(out).toContain("windswept dome");
+    expect(out).toContain("<strong>Population:</strong> Few");
+    expect(out).toContain("<strong>Authority:</strong> Fair");
+    expect(out).toContain("<strong>Projects:</strong> Raiding");
+    expect(out).toContain("<strong>Trouble:</strong> Pirates");
+    expect(out).toContain("&middot;");  // facts joined with " · "
+  });
+
+  it("includes the stellar object line when present (F7 wire)", () => {
+    const out = composeSettlementDescription(
+      "<p>An orbital ring.</p>",
+      { stellar: "blazing blue star" },
+    );
+    expect(out).toContain("<strong>Stellar object:</strong> blazing blue star");
+  });
+
+  it("renders prose-only when no rolled details exist", () => {
+    const out = composeSettlementDescription("<p>Just prose.</p>", {});
+    expect(out).toBe("<p>Just prose.</p>");
+  });
+
+  it("renders facts-only when no prose is provided", () => {
+    const out = composeSettlementDescription("", { population: "Few" });
+    expect(out).toContain("<strong>Population:</strong> Few");
+    expect(out).not.toContain("<hr>");
+  });
+
+  it("wraps a plain-text prose argument in a <p>", () => {
+    const out = composeSettlementDescription("Plain text.", {});
+    expect(out).toBe("<p>Plain text.</p>");
+  });
+
+  it("escapes HTML in facts to prevent injection from oracle results", () => {
+    const out = composeSettlementDescription("<p>x</p>", { trouble: "<script>x</script>" });
+    expect(out).toContain("&lt;script&gt;");
+    expect(out).not.toContain("<script>");
+  });
+});
+
+
+// ─────────────────────────────────────────────────────────────────────────────
+// generateSector — F7 stellar object roll is shared across all settlements
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("generateSector — F7 stellar object roll", () => {
+  it("rolls a stellar object and writes the same value onto every settlement", () => {
+    const sector = generateSector("terminus");
+    const stellars = sector.settlements.map(s => s.stellar);
+    expect(stellars[0]).toBeTruthy();
+    for (const s of stellars) {
+      expect(s).toBe(stellars[0]);
+    }
   });
 });


### PR DESCRIPTION
## Initiating prompt

> the settlement actor only has flavor text, misses the oracle rolls that went with it
>
> big improvements on the Actor for the settlement but it still doesn't record the type of settlement
>
> we aren't using the ironsworn-starforged module Actor type Location for the planets, and their type of star, which is a cool drop down we should try to make more use of
>
> The potential connection comes with a Goal, but it seems like that information is immediately lost.

(Screenshots attached across the catalog: settlement Actor sheet with blank "Type of settlement" dropdown and prose-only description; sector preview showing Lagrange as `Orbital, Dozens, Corrupt` with the connection rolling a `Goal: Collect a debt`. Tier 2 of the v1.7.0 playtest findings — F3 / F6 / F7 / F17.)

## Summary

Single rolled-data → Actor-sheet-field sweep across four of the v1.7.0 playtest findings. The defect class was the same for all four: the sector wizard rolled oracle data, passed it to the entity creators, the creators stored it on the module flag — but didn't write it where the sheet displays it.

### F6 — "Type of settlement" dropdown empty
The foundry-ironsworn `LocationModel.klass` field for `subtype=settlement` is one of `planetside` | `orbital` | `deep space` (lowercase, single space, no synonyms — confirmed by reading `vendor/foundry-ironsworn/src/module/actor/subtypes/location.ts` and `vendor/foundry-ironsworn/src/module/vue/sf-locationsheet.vue`). The wizard was writing `Planetside` / `Orbital` / `Deep Space` (titlecase) so the sheet's dropdown couldn't match and rendered blank. Same defect on planet: schema expects `desert` / `furnace` / … / `vital`; the wizard was writing `Desert World` / `Furnace World` / … / `Vital World`.

New `normaliseSettlementKlass` / `normalisePlanetKlass` helpers map the wizard's display strings onto the canonical enum on both `createXxx` and `updateXxx`. The planet helper also strips the trailing `World` suffix.

### F3 — Connection Goal dropped after Create Sector
`goal` was rolled at sector creation and passed into `createConnection`, but `ConnectionSchema` had no `goal` field — the value rode along on the flag payload as a non-canonical extra, and `renderEntityBody` (which seeds the journal page body) never surfaced it. `goal` is now a documented schema field and renders as a labelled `<strong>Goal:</strong> …` line on the connection's journal page.

### F17 — Settlement Actor only carried flavour text
The narrator stub overwrote the description with prose only; Population / Authority / Projects / Trouble / First-look / Initial-contact (all rolled by the wizard) never appeared on the sheet. The location-actor schema in foundry-ironsworn only exposes `subtype` / `klass` / `description` as structured fields — the per-settlement rolled details have no `system.population` / `system.authority` slot to write to. So `applyStubsToSettlementEntities` now composes the description body via a new exported helper `composeSettlementDescription(prose, data)` that pairs the narrator prose with a structured, dot-separated facts line drawn from the settlement's flag. Both surfaces visible at once on the sheet.

### F7 — Stellar object never rolled
`generateSector` never rolled `SPACE.STELLAR_OBJECT`, even though `sectorGenerator.js` reserves a `stellar: null` slot and `sceneBuilder.js → iconForStellarObject` was already wired up to draw a stellar pin on the scene map (just starved of data). `generateSector` now rolls it once per sector and threads it through every settlement's `stellar` field; the wizard passes it into `createSettlement` so it lands on the flag; `composeSettlementDescription` surfaces it in the description block. The dead-wired scene-map stellar pin path now actually fires.

### F18 — Deferred
Ship modules mismatching the rolled narrative is intentionally **out of scope**. Modules are foundry-ironsworn Items, not flat `system.*` fields, so rolling type/first-look/mission to a module choice needs a mapping table that doesn't belong in this surface sweep. Its own scope.

## Coverage

- **9 new unit tests + 2 updated:**
  - `tests/unit/entityLocationFamilyActor.test.js` — 3 tests **updated** to expect the canonical lowercase klass values (`planetside` / `orbital` / `furnace`); they were previously encoding the bug.
  - `tests/unit/entityPageBody.test.js` — 2 new tests pinning that the connection journal body surfaces the rolled Goal and omits it cleanly when empty.
  - `tests/unit/sectorGenerator.test.js` — 6 new tests on the new `composeSettlementDescription` helper (prose-and-facts pairing, stellar surfacing, prose-only branch, facts-only branch, plain-text wrapping, HTML escaping); 1 new test pinning that the shared stellar roll is propagated to every settlement in a sector; and 2 existing `applyStubsToSettlementEntities` tests updated to expect the composed description shape.
- Existing 1722 tests still pass (1731 with the new ones); lint clean.

## CHANGELOG harmonization

`CHANGELOG.md` and `src/help/helpJournal.js` v1.7.1 block are harmonized with the four existing v1.7.1 PRs (#149 / #150 / #151 / #152) — all five branches now carry the same five-bullet `[Unreleased]` block. Each PR can merge in any order without CHANGELOG conflicts (verified by SHA256-hash of both files across all five branches).

## Files changed

- `src/entities/settlement.js` — `normaliseSettlementKlass` helper; create/update mirror through it; new `stellar` field on SettlementSchema.
- `src/entities/planet.js` — `normalisePlanetKlass` helper; create/update mirror through it.
- `src/entities/connection.js` — `renderEntityBody` surfaces `goal`.
- `src/schemas.js` — `goal: ""` added to `ConnectionSchema`.
- `src/sectors/sectorGenerator.js` — `generateSector` rolls `SPACE.STELLAR_OBJECT`; passes through to `createSettlement`; new exported `composeSettlementDescription`; `applyStubsToSettlementEntities` uses it.
- `tests/unit/entityLocationFamilyActor.test.js` — klass expectation updates.
- `tests/unit/entityPageBody.test.js` — Goal coverage.
- `tests/unit/sectorGenerator.test.js` — composeSettlementDescription + generateSector stellar coverage.
- `CHANGELOG.md` + `src/help/helpJournal.js` — Tier 2 entry; harmonized v1.7.1 block.

## Test plan

- [x] `npm test` — 1731/1731 pass.
- [x] `npm run lint` — clean.
- [ ] **Live verify on Forge**:
  - Run Sector Creator → confirm settlement Actor's "Type of settlement" dropdown is populated (Planetside / Orbital / Deep Space).
  - Confirm settlement sheet description shows both the narrator prose AND a dot-separated facts line with Population / Authority / Projects / Trouble / Stellar object.
  - Confirm the resulting connection's journal page shows a `Goal:` line under the description.
  - Open the sector Scene and confirm the stellar object pin renders.

## Catalog

Closes **F3 / F6 / F7 / F17** from the v1.7.0 playtest findings. F18 (ship module mapping) deferred to its own scope.

https://claude.ai/code/session_01Syjhqwk5xgL5fAeW28vPsj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Syjhqwk5xgL5fAeW28vPsj)_