### PR TITLE
docs: add coupling and mock-fidelity rules for CI and testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,19 @@ you to address a specific one in the current session conversation.
   for confirmation before making the change
 - **Implement only when asked:** a user describing a problem is not the same as
   a user asking you to fix it
+- **Audit consumers when meaning changes:** when changing what a document type,
+  flag, or setting default *means* (e.g. a new use of an actor type, flipping a
+  default), grep for **every consumer** of that type/flag/setting — `src/`,
+  `tests/`, and `src/integration/quench.js` — and update them in the same
+  commit. Three of the four v1.7.6 playtest bugs came from one unaudited
+  type-meaning change (NPCs becoming `character` actors).
+- **Settled decisions: search, don't re-derive.** If the user says a decision
+  was already made, find it (`decisions.md`, scope docs,
+  `docs/testing/*playtest-findings*`) before re-opening it. If a doc
+  contradicts the user, the doc is stale — correct it **and** record the
+  decision in `decisions.md` in the same commit. Decisions that live only in
+  scope docs get lost between sessions; `decisions.md` is the durable home
+  (the FOLDER-002 "no native NPC actor type" loop is the cautionary example).
 
 When in doubt about whether something is in scope for the current session,
 ask rather than proceed.
@@ -107,6 +120,11 @@ After completing any feature implementation or bug fix, always update both:
 
 2. **`CHANGELOG.md`** — the GitHub changelog:
    - Add an entry under `[Unreleased]` for the change
+   - **Promote on the next change after a release:** once a release is tagged,
+     the now-shipped `[Unreleased]` content still sits under that heading. The
+     next change's docs commit promotes it to its own `## [x.y.z] — date`
+     section (per the fetched latest tag) and starts a fresh `[Unreleased]`
+     for the new work. Don't open a PR just for the promotion.
 
 **Help file changelog format** (in `packs/help.json`, "Changelog" page):
 ```html
@@ -208,6 +226,10 @@ when the work involves an iterative CI loop where the loop body is
   `python3 -c "print(open(file).read()[A:B])"` if so.
 - WebFetch cannot read GitHub Actions step logs (auth-gated) or
   workflow artifact zips. Don't try; use the PR-comment bridge instead.
+- When delegating research to a sub-agent, verify its **"no changes needed" /
+  no-op claims** against the source before relying on them — a blast-radius
+  report once claimed `connection.js` needed no changes when its create path
+  explicitly built the old document type.
 - See `rules/ci-e2e.md` for the full pattern, including how the workflow
   populates the sticky comment.
 
@@ -233,6 +255,13 @@ These are deliberate decisions — do not change without reading
 - Chat message type must not be `"other"` — not valid in Foundry v13.
 - All actor reads and writes go through `src/character/actorBridge.js`.
   Never access Actor fields directly from other modules.
+- NPC/connection cards are `character`-type Actors tagged with
+  `flags[MODULE].entityType` (FOLDER-002). **Never use `type === 'character'`
+  alone to mean "player character"** — use `isPlayerCharacterActor()` /
+  `getPlayerActors()` from `actorBridge.js`, or replicate the entityType-flag
+  exclusion where importing actorBridge isn't possible. An unfiltered check
+  leaks NPC cards into PC-only logic (momentum grants, chat-speaker
+  attribution, narrator CHARACTER STATE).
 
 ---
 

--- a/rules/ci-e2e.md
+++ b/rules/ci-e2e.md
@@ -90,6 +90,39 @@ If the suite shrinks below ~100 active tests in the future, the absolute backsto
 
 **Out of code's reach:** the workflow must be a required status check on `main` (see Repo settings prerequisites above), otherwise none of this matters at merge time.
 
+## Quench batch coupling — shared defaults and hooks
+
+Settings defaults and module hooks are **shared state across all Quench
+batches**. Changing a world-setting default or removing/redirecting a hook
+breaks batches that *implicitly* relied on the old behaviour — typically in
+batches you didn't write and didn't touch. Each instance cost a full CI
+round-trip in practice:
+
+- Flipping `autoSeedStarship` to default-off broke `starshipNarratedNotes`,
+  which created a starship and waited for the createActor hook to populate
+  Notes without ever pinning the setting.
+- The connection-seed hook (`autoSeedConnection`, then default-on) broke the
+  `portraitGeneration` gating test by populating `portraitSourceDescription`
+  on a card the test expected blank.
+- Removing the scene-controls group broke a `privateChannel` assertion that
+  still called `getSceneControlButtons`.
+
+Rules:
+- Before changing a setting default or hook behaviour, **grep
+  `src/integration/quench.js` for every batch that exercises that path**
+  (the setting key, the hook name, the mechanism's selectors/flags) and
+  update them in the same commit — don't wait for CI to find them.
+- A batch that depends on a specific setting value must **pin it with
+  `withTempSetting(...)`** rather than assuming the default; defaults are
+  allowed to change.
+- Hooks that read settings should read them **synchronously at fire time**,
+  not inside a deferred async block — a deferred read races
+  `withTempSetting`'s restore (see `registerStarshipSeedHook` in
+  `src/index.js`).
+- The e2e suite can't run locally in every environment; when a change lands
+  in this category, expect one CI iteration and budget for it rather than
+  assuming the first push is green.
+
 ## Accepted blind spots
 
 ### `cacheKey is stable and content-addressed` (audio batch) — secure-context skip

--- a/rules/foundry-ironsworn.md
+++ b/rules/foundry-ironsworn.md
@@ -67,6 +67,16 @@ vendor/foundry-ironsworn/src/module/model/item/
 6. Stats are flat on system: `system.edge`, not `system.stats.edge`
 7. XP is a flat number: `system.xp`, not `system.xp.value`
 8. Starship is a separate Actor (`type: "starship"`), not an embedded item
+9. The system **does** ship `character` / `npc` / `foe` / `starship` /
+   `location` / `shared` / `site` actor types — never assert an actor type
+   doesn't exist without checking `vendor/.../system/template.json`. (A stale
+   "no native NPC actor type" note once deferred connection migration for
+   multiple releases.)
+10. The Companion uses `character` for **both** PCs and NPC/connection cards,
+    distinguished by `flags[MODULE].entityType` (present = NPC card, absent =
+    PC). Sheet-label field mapping: the "Characteristics" header field is
+    `system.biography`; the "Notes" tab is `system.notes` (verified against
+    `sf-characterheader.vue` / `sf-notes.vue`).
 
 **When updating `tests/setup.js` actor mock:**
 The `makeTestActor` factory must match the real schema exactly.

--- a/rules/quench.md
+++ b/rules/quench.md
@@ -81,3 +81,28 @@ const MODULE_PATH = "/modules/starforged-companion/src";
 await import(`${MODULE_PATH}/context/safety.js`)  // works
 ```
 Static imports at file top resolve correctly. Only dynamic import() has this behaviour.
+
+## Unit-test mock fidelity (vitest harness, `tests/setup.js`)
+
+Mocks standing in for Foundry APIs must match the **real Foundry v13 return
+shape**, not what's convenient for assertions. A convenient-but-wrong mock
+doesn't just miss bugs — it actively conceals them by making broken production
+code pass CI.
+
+Known trap (cost multiple releases): Foundry v13's `Folder#folder` getter
+returns the parent Folder **document**, while the shared mock stored `folder`
+as an id string. `ensureFolderPath`'s parent comparison passed against the
+mock and silently failed in production, minting a duplicate sector folder on
+every world load (FOLDER-001). Same family: `Actor#folder` is also a document
+in v13 — code must normalise via `folderParentId()` (`src/entities/folder.js`)
+or `actor.folder?.id ?? actor.folder`.
+
+Rules:
+- When fixing a bug the unit mocks missed, write the regression test against
+  the **production shape** (e.g. seed a document-style parent ref), not the
+  mock's existing convention — otherwise the test re-encodes the blind spot.
+- When touching `tests/setup.js` mocks, check the real shape in
+  `docs/foundry-reference/foundry-api-reference.md` or the vendor source
+  before extending the mock's behaviour.
+- A passing unit suite plus a live-Foundry failure usually means a mock-shape
+  divergence — diff the mock against the v13 API before debugging the code.


### PR DESCRIPTION
## Summary

This PR documents critical lessons learned from recent CI failures and unit-test blind spots. It adds three new rule sections to prevent recurring issues:

1. **Quench batch coupling** (`rules/ci-e2e.md`) — shared state across e2e test batches creates hidden dependencies that break silently when defaults or hooks change
2. **Unit-test mock fidelity** (`rules/quench.md`) — mocks that diverge from real Foundry v13 API shapes actively conceal bugs
3. **Consumer audits on meaning changes** (`CLAUDE.md`) — when a type, flag, or setting's meaning changes, all consumers must be updated in the same commit

## Key changes

- **`rules/ci-e2e.md`**: Added "Quench batch coupling — shared defaults and hooks" section documenting three real incidents (starship seed, connection seed, scene controls) and rules for safe changes to world settings and module hooks
- **`rules/quench.md`**: Added "Unit-test mock fidelity" section with the `Folder#folder` document-vs-id trap (FOLDER-001) and rules for regression testing against production shapes
- **`CLAUDE.md`**: 
  - Added "Audit consumers when meaning changes" rule with the v1.7.6 NPC actor-type example
  - Added "Settled decisions: search, don't re-derive" rule to prevent re-opening resolved decisions (FOLDER-002 cautionary example)
  - Added guidance on CHANGELOG.md promotion after releases
  - Added sub-agent verification rule for blast-radius claims
  - Expanded actor-type rules with the `character`-type NPC/connection card pattern and `isPlayerCharacterActor()` requirement
- **`rules/foundry-ironsworn.md`**: Added items 9–10 documenting the system's native actor types and the Companion's use of `character` for both PCs and NPC cards with `entityType` flag distinction

## Notable details

These are all documentation-only changes capturing decisions already made during incident postmortems. No code logic changes. The rules are written to be actionable (grep patterns, specific function names, concrete examples) rather than abstract.

The NPC/connection card pattern (item 10 in foundry-ironsworn.md) is particularly important: it clarifies that `character` type is used for both player characters and NPC cards, with the distinction made via `flags[MODULE].entityType`, and provides the correct sheet-label field mappings (`system.biography` for Characteristics, `system.notes` for Notes tab).

https://claude.ai/code/session_01MvZpDT7SKRfmhj67zo662W