### PR TITLE
docs: v1.7.16 post-release follow-up (close finding A + promote CHANGELOG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Starforged Companion are documented here.
 
 ## [Unreleased]
 
+## [1.7.16] — 2026-06-18
+
 - Changed: **During a fight, your actions are rolled, not narrated.** Once combat is active (an open combat track), any action you describe — shooting, maneuvering, taking cover, or threatening under fire — is treated as a suggested outcome that triggers a move and a roll, in any category. You can no longer end a fight by simply asserting that you cut down the enemy; the dice decide. Pure observation ("the bay fills with smoke") still reads as narration.
 - Fixed: **You can find your combat track.** When a fight starts, the "Enter the Fray" card now carries an "Open Progress Tracks" button that jumps straight to where the fight's progress, rank, and in-control / bad-spot position live. The narrator also actually sees your active tracks now: the context section that lists vows, expeditions, and combat tracks was reading the wrong storage location and came up empty in play, so the narrator could mention a combat track you couldn't locate — fixed.
 - Fixed: **NPC portraits no longer fail when the fiction is violent.** A character introduced through a kidnapping, raid, or bloody scene could fail portrait generation outright ("Content Moderated"). The portrait prompt now neutralises captivity/raider/violence wording, and if the image provider still refuses, it automatically retries with a clean, card-only portrait prompt (gender, role, style) that drops the scene description. Only if both fail is the portrait skipped — with a clear message.

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -16,7 +16,7 @@ _Last audited against the code at v1.6.0 (2026-05)._
 except **E** (config/discoverability — setting hint clarified; not a code bug)
 and **H** (diagnostics added; root cause needs the Tier-3 audio smoke to confirm
 live). **K** was resolved by the M/N move-lock fix. Finding **A**'s camera fix
-should be eyeballed in a live session (geometry can't be unit-verified). See the
+was **confirmed fine in a live session (2026-06-18) — closed.** See the
 cluster notes and individual entries. Two-player session (GM + one non-GM
 player); PCs Kylar Nazari and Mave Takara in the Igneous Maze sector.
 
@@ -148,10 +148,11 @@ the initial-view centre **explicitly** to `(sceneX + sceneWidth/2, sceneY +
 sceneHeight/2)` from the same offset (not relying on Foundry's default centring,
 which is unverifiable here). Content and camera now derive from one offset and
 cannot drift apart. Tests: `tests/unit/sectorSceneBuilder.test.js` (offset +
-centred-camera + dimensions-fallback). Camera geometry still can't be
-unit-verified — confirm the load view is centred and the pins sit on the
-background in a live session. See `decisions.md` → "Sector scene padding: never
-zero" → the 2026-06-15 placeable-offset refinement.
+centred-camera + dimensions-fallback). Camera geometry can't be
+unit-verified, but the load view was **confirmed centred with the pins on the
+background in a live session (2026-06-18) — finding A closed.** See
+`decisions.md` → "Sector scene padding: never zero" → the 2026-06-15
+placeable-offset refinement.
 
 **Files:** `src/sectors/sceneBuilder.js` (`sceneRectOffset`, note/drawing/token
 placement, `initial` centre).


### PR DESCRIPTION
## Initiating prompt

> Open a pr for anything that missed that release

(Context: said immediately after the maintainer confirmed "Great. Tag v1.7.16 released." The v1.7.16 PR #180 had already been merged and tagged; two doc commits landed on the branch after that merge window and were therefore not in the released commit.)

## What missed the release

PR #180 was merged into `main` and tagged **v1.7.16** at the merge commit. Two documentation commits landed on `claude/v1.7.16-playtest-fixes` *after* that merge, so they are not in `origin/main`:

1. **`docs: close PLAYTEST-1712 finding A`** — the v1.7.14 sector-map placeable/camera fix was the last PLAYTEST-1712 item awaiting live confirmation (geometry can't be unit-verified). The maintainer confirmed in a live session (2026-06-18) that the camera loads centred with pins on the background. Marked closed in both the cluster summary and the finding A entry in `docs/known-issues.md`.

2. **`docs: promote v1.7.16 CHANGELOG section`** — v1.7.16 is now tagged, so per the changelog-maintenance rule the first post-release change promotes the shipped `[Unreleased]` content to its own dated section (`## [1.7.16] — 2026-06-18`) and opens a fresh `[Unreleased]`. No content was changed — the entries are identical, just moved under the dated heading. (The rule says *don't* open a PR solely for the promotion, so it rides along with the finding-A follow-up here.)

## Scope

Docs-only. No source changes, no `module.json` / `CONTENT_VERSION` change (the help journal's `CONTENT_VERSION` already reads `1.7.16`, matching the live tag, and neither change is user-facing). `npm test` (2446 passing) and `npm run lint` (0 errors) both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nD9TZKAeTWpfVXcFVgU63

---
_Generated by [Claude Code](https://claude.ai/code/session_011nD9TZKAeTWpfVXcFVgU63)_