### PR TITLE
docs: add Sundered Isles guidebook + Ironsworn: Delve rules summaries

### DIFF
--- a/docs/rules-reference/delve-rulebook-summary.md
+++ b/docs/rules-reference/delve-rulebook-summary.md
@@ -1,0 +1,375 @@
+# Ironsworn: Delve — Rulebook Summary
+
+A chapter-by-chapter paraphrased summary of the Ironsworn: Delve
+supplement, intended as design context for Claude Code. The summary
+covers the site-delving system, the new moves, the theme/domain
+generators, the optional subsystems, and the design intent. It
+deliberately omits the oracle tables (Chapter 8), the denizen stat
+blocks (Chapter 5), and the detailed threat/item reference (Chapters
+6–7), since those are data the foundry-ironsworn ecosystem exposes, and
+omits the book's prose, art, and verbatim move text.
+
+**Source:** Ironsworn: Delve (Shawn Tomkin, 2020), digital edition. Text
+licensed CC BY-NC-SA 4.0.
+
+**Critical framing:** Delve is a supplement for the **original Ironsworn**
+(the fantasy game set in the Ironlands), **not** for Starforged. It
+predates Starforged by two years. This matters because the module is
+Starforged-focused, and the relationship runs the other way from the
+other expansions: Delve's site-exploration system was the *prototype*
+that Starforged later generalized into its **expedition** mechanics
+(Undertake an Expedition / Explore a Waypoint / Finish an Expedition are
+the Starforged descendants of Delve's site moves). So this summary is
+most useful as (a) historical/design context for understanding where
+Starforged's expedition system came from, and (b) a source of reusable
+abstractions — themes, domains, the denizen matrix, risk zones — that a
+Starforged-based module could draw on if it ever wanted richer
+location-generation than Starforged ships with.
+
+Delve assumes and reuses the entire original Ironsworn engine: the action
+roll (action die + stat vs. two challenge dice), momentum, progress
+tracks and ranks (troublesome → epic), condition meters (health, spirit,
+supply), and the move framework. The original Ironsworn engine is the
+direct ancestor of Starforged's, so the mechanics will feel familiar:
+the differences from Starforged are mostly naming and the absence of
+some Starforged refinements (e.g., Ironlands uses health/spirit/supply
+where the systems are near-identical in spirit).
+
+**What this is for:** When Claude Code reasons about location generation,
+expedition mechanics, procedural site content, or richer
+dungeon/site-style play within a Starforged campaign, this is the
+reference. For verbatim rules, denizen stats, oracle tables, or move
+text, consult the actual supplement or the foundry-ironsworn system data.
+
+---
+
+## The core idea: sites
+
+Delve's central addition is the **site** — a discrete, perilous location
+(ruin, cavern, swamp, barrow, stronghold) that a character explores in
+pursuit of a vow-related objective. A site is the fantasy-dungeon
+analogue, but generated and resolved through progress tracks and oracles
+rather than mapped room-by-room in advance.
+
+A site is always tied to a vow. You delve because a quest compels you:
+an ancient weapon lies in a haunted barrow, an enemy leader shelters in a
+fortified stronghold, a corrupted wood blocks your path. Overcoming the
+site's objective typically lets you Reach a Milestone or Fulfill Your Vow
+on the related quest.
+
+A site has four defining properties, set when you Discover it:
+
+- A **theme** (its condition/nature)
+- A **domain** (its physical form)
+- A **rank** (troublesome → epic, governing scale and progress rate)
+- A set of **denizens** (who/what dwells there)
+
+---
+
+## Chapter 1 — At the Threshold (setup)
+
+How to prepare a delve.
+
+### The seven new moves (overview)
+Delve adds seven moves, fully detailed in Chapter 2:
+
+- **Discover a Site** — made when a site enters the narrative; choose
+  theme, domain, and rank
+- **Delve the Depths** — the core exploration move, made repeatedly as you
+  search; marks site progress and may trigger opportunities or dangers
+- **Find an Opportunity** — triggered by a strong hit (and sometimes a weak
+  hit) on Delve the Depths; a helpful feature or situation
+- **Reveal a Danger** — triggered by a miss (and sometimes a weak hit) on
+  Delve the Depths; a risk or obstacle to overcome
+- **Check Your Gear** — test whether you happen to have a useful item
+- **Locate Your Objective** — the progress move that resolves whether you
+  find what you came for; compares site progress to the challenge dice
+- **Escape the Depths** — resolves fleeing or withdrawing from a site in a
+  single roll
+
+### Discover a Site, in detail
+When you resolve to enter a site, choose the theme and domain that fit
+(or Ask the Oracle), and assign a rank. The rank sets progress per "area"
+explored, on the standard Ironsworn scale:
+
+- Troublesome — 3 progress per area
+- Dangerous — 2
+- Formidable — 1
+- Extreme — 2 ticks
+- Epic — 1 tick
+
+Formidable is the suggested default — a good balance of challenge and
+real-world time. A troublesome site is a few chambers resolved in
+minutes; an epic site is unknowable depths spanning multiple sessions.
+
+Returning to a previously fled site: roll both challenge dice, take the
+lowest, and clear that many progress boxes (the retreat cost).
+
+### Themes (8)
+The theme is the site's condition and indicates the denizens and threats
+likely present. Each theme is a tarot-sized card carrying oracle tables
+for **features** and **dangers**:
+
+| Theme | Nature |
+|---|---|
+| Ancient | Holds the secrets of a bygone age |
+| Corrupted | Tainted by dark magic |
+| Fortified | Foes defend it against intruders |
+| Hallowed | The faithful worship here |
+| Haunted | Restless spirits are bound here |
+| Infested | Foul creatures dwell here |
+| Ravaged | Time, disaster, or strife have taken their toll |
+| Wild | Nature prevails |
+
+### Domains (12)
+The domain is the site's physical form — the terrain or architecture
+traversed. Each domain is also a card with feature and danger oracles:
+
+| Domain | Form |
+|---|---|
+| Barrow | The dead are enshrined here |
+| Cavern | Stone and darkness |
+| Frozen Cavern | Deep caves and enduring cold |
+| Icereach | A frigid landscape of frozen seas |
+| Mine | Tunnels dug greedily and deep |
+| Pass | Treacherous paths over high mountains |
+| Ruin | The crumbling legacy of a dead civilization |
+| Sea Cave | Stone passages carved by ocean waves |
+| Shadowfen | A primeval mist-cloaked marsh |
+| Stronghold | A fortress secured against trespassers |
+| Tanglewood | A perilous forest of eternal shadow |
+| Underkeep | An age-old subterranean dungeon |
+
+Theme and domain combine to define a site. "Infested Barrow," "Corrupted
+Cavern," "Fortified Stronghold" — the pairing drives the fiction and
+provides two oracle tables each for features and dangers. Either can be
+chosen deliberately or randomly (draw a card, roll the oracle, or pick a
+preset "site starter"). On a feature roll of 99/00, the site **transitions**
+into a new theme or domain mid-exploration — a built-in mechanic for sites
+that change character as you go deeper.
+
+### Denizens and the denizen matrix
+Denizens are the site's inhabitants. They're populated via the **denizen
+matrix** on the site worksheet — slots rated **very common / common /
+uncommon / rare / unforeseen**, each keyed to a range on a d100 roll. At
+setup the player fills in a few denizens suggested by the theme and
+domain and leaves most slots blank, filling them during play as encounters
+arise. When a move calls for a denizen encounter, the player can choose
+one from the matrix, roll on it, or Ask the Oracle.
+
+Denizens have minimal mechanical footprint, like all Ironsworn/Starforged
+NPCs: a rank plus fiction. The matrix is a lazy-generation tool — the site's
+population is discovered through play, not pre-statted. Chapter 5 provides
+the bestiary; this summary doesn't duplicate it.
+
+### Envision the scene
+The setup closes with envisioning the threshold — standing at the site's
+edge, imagining what lies before you. Standard Ironsworn "envision before
+mechanics" framing.
+
+---
+
+## Chapter 2 — Into the Depths (the play loop)
+
+The moment-to-moment flow of delving.
+
+### The Delve the Depths loop
+The heart of the system. You repeatedly **Delve the Depths**, rolling
++ a stat appropriate to your approach (edge for speed, shadow for stealth,
+wits for navigation, iron for forcing through, heart for resolve). Each
+roll:
+
+- **Strong hit** — mark progress and Find an Opportunity (a good
+  development)
+- **Weak hit** — mark progress, then either Find an Opportunity or Reveal
+  a Danger (your choice or the oracle's, depending on the variant)
+- **Miss** — Reveal a Danger (a threat with no progress)
+
+This loop continues, marking the site progress track, until you decide to
+**Locate Your Objective** — the progress move that resolves whether the
+thing you came for is found. As with all Ironsworn progress moves, you
+roll the *tally of filled progress boxes* against the two challenge dice,
+not a stat. Strong hit: you find it cleanly. Weak hit: found, but with a
+catch. Miss: it's not here, or finding it brings a dire complication.
+
+Find an Opportunity and Reveal a Danger each have their own oracle tables
+(general ones, plus the theme- and domain-specific feature/danger tables).
+This is what makes the site feel populated and unpredictable without
+prep — the opportunities and dangers are generated as you go.
+
+### Escape the Depths
+If a delve goes wrong — overwhelming dangers, broken body or sanity — the
+player can **Escape the Depths**, a single roll resolving the flight out.
+It's a mechanical and narrative shortcut; you don't re-delve the whole
+site to leave. Fleeing forfeits site progress (paid back on return).
+
+### The flow and core terms
+The chapter closes with a flow diagram and a glossary of core terms (site,
+theme, domain, rank, area, progress, denizen, objective). The conceptual
+shape: Discover → (Delve the Depths → Opportunity/Danger)×N → Locate Your
+Objective → resolve the vow, or Escape the Depths if it goes bad.
+
+---
+
+## Chapter 3 — Finding Your Path (options)
+
+Entirely optional techniques and variant rules, many useful in any
+Ironsworn campaign, not just delving.
+
+### Managing sites and quests
+When the site objective *is* the quest objective, keep **two separate
+progress tracks**: the site track (physical headway) and the vow track
+(narrative potential to Fulfill Your Vow). Set the quest rank a step or
+two below the site rank. Within the site, mark site progress on Delve the
+Depths and mark vow milestones as you overcome quest-relevant obstacles —
+giving the delve and the quest parallel, interlocking pacing. The GM (or
+the solo player) uses the two tracks as pacing tools: if the delve is
+outrunning the quest, introduce milestone obstacles.
+
+### Risk zones (optional escalation)
+Segments the site progress track into three zones of escalating danger:
+
+- **Low risk** (0–3 progress) — troublesome or dangerous foes
+- **Medium risk** (4–7 progress) — dangerous or formidable foes
+- **High risk** (8–10 progress) — formidable or extreme foes
+
+The deeper you go, the worse it gets. The site's overall rank biases which
+of each zone's two options you face. This is the mechanical expression of
+"the heart of the site is the most dangerous part" — an elegant way to
+make depth meaningful without tracking position.
+
+### Learning from failure
+A new advancement mechanic: when you fail to overcome challenges, you can
+**mark your failure**, and later **learn from your failures** to gain a
+benefit (a reroll, a bonus, or experience). Turns misses into long-term
+character growth — a soft counter to the harshness of the dice.
+
+### Other options
+- **Mapping a site** — tips for drawing a visual map as you explore (the
+  map is generated through play, not prepared)
+- **Relationship maps** — diagramming how the people, creatures, and forces
+  within a site relate (rivalries, alliances, hierarchies)
+- **Streamlining dice rolls** — three speed-up options: "go with your gut"
+  (skip oracles when you have an idea), "let it ride" (carry a result
+  forward), and "casting runes" (a tactile oracle alternative)
+- **Hacking sites** — playing without theme/domain cards, alternate Reveal
+  a Danger, combining multiple themes/domains, creating your own, drawing
+  inspiration from published adventures
+- **Delves as journeys** — using the Delve mechanics to resolve overland
+  travel (the conceptual bridge to Starforged's expedition system)
+- **One-shot delves** — running a self-contained site adventure as a
+  one-shot
+
+---
+
+## Chapter 4 — Sites (setting reference)
+
+How sites fit a given version of the Ironlands, plus detailed
+theme/domain descriptions and 20 preset **site starters** (named locations
+with backgrounds and suggested denizens — e.g., Themon's Rest, Bleakroot
+Depths, Darkfall Caves).
+
+### Sites in alternative settings
+Notably, the theme/domain system is deliberately setting-abstract. The
+book explicitly suggests reusing it in other genres: Ancient Ruins in a
+hollow asteroid (sci-fi), a Fortified Underkeep as a VR construct
+(cyberpunk), a Corrupted Sea Cave for Lovecraftian cultists. The feature
+and danger oracles are abstract enough to reinterpret for any setting.
+**This is the design seam that makes Delve's content reusable in a
+Starforged module** — themes and domains aren't locked to fantasy.
+
+### Your truths
+Like the core games, the campaign's established truths shape site
+selection. Delve frames this as a set of yes/no questions rather than its
+own truth categories (it uses the *original Ironsworn* truths from the
+core book, page 122 — a different set again from Starforged's 14 and
+Sundered Isles' 11). Sample questions: Is warfare dominant? (→ more and
+stronger Fortified sites.) Does religion influence the world? (→ Hallowed
+sites as sanctuaries, or exclude the theme.) The truths determine which
+themes make sense and at what ranks.
+
+---
+
+## Chapters 5–8 (summarized briefly)
+
+### Chapter 5 — Denizens
+The bestiary: a roster of foes organized by type (Ironlanders, Firstborn,
+Animals, Beasts, Horrors, Anomalies), each with a rank, fiction prompts,
+and features. Includes guidance on the denizen matrix in play. These are
+data; the foundry ecosystem exposes them and this summary doesn't
+reproduce them.
+
+### Chapter 6 — Threats (optional subsystem)
+Mechanics for tracking malevolent forces working against the player's
+vows — a threat has a category, a countdown/progress structure, and
+escalating consequences as it advances. Conceptually similar to
+Starforged's campaign clocks, but with more structure. Optional.
+
+### Chapter 7 — Objects/Items of Power (optional subsystem)
+Mechanics and inspiration for unique magical items — how to generate them,
+their boons and banes, and how they integrate with assets. Optional.
+
+### Chapter 8 — Oracles
+New oracle tables for generating sites, denizens, monstrosities, names,
+and answering questions. Data; not reproduced here.
+
+---
+
+## Implications for module design
+
+Observations relevant to a Starforged-based module:
+
+1. **Delve is the ancestor of Starforged's expedition system.** A module
+   already supporting Undertake an Expedition / Explore a Waypoint /
+   Finish an Expedition is already implementing the descendant of Delve's
+   core loop. Understanding Delve clarifies the *design intent* behind
+   those Starforged moves: an expedition is a site delve, generalized to
+   space travel. The progress-track-plus-oracle-driven-discovery shape is
+   identical.
+
+2. **Themes and domains are reusable, setting-abstract content.** If the
+   module ever wants richer procedural location generation than Starforged
+   ships with — for derelicts, vaults, planetary sites, ship interiors —
+   the theme/domain pattern (a condition card + a form card, each with
+   feature and danger oracles, combined to define a location) is a proven,
+   genre-portable abstraction. The book itself endorses sci-fi reuse.
+
+3. **The denizen matrix is a lazy-population pattern worth knowing.** The
+   "fill a few slots, leave the rest blank, generate the rest through
+   play" approach to populating a location maps well onto how a narrator
+   could lazily generate inhabitants of a Starforged site or derelict,
+   rather than pre-statting everything. The matrix's common/uncommon/rare
+   weighting is a clean probability structure.
+
+4. **Risk zones are a depth-equals-danger mechanic.** The three-zone split
+   of a progress track (low/medium/high risk by how deep you are) is a
+   tidy way to make exploration depth meaningful without position
+   tracking — relevant given the module explicitly dropped physical
+   position tracking from fact-continuity. If a Starforged site or
+   expedition wants escalating peril, this is the pattern.
+
+5. **Transitions are a built-in "the site changes" mechanic.** Delve's
+   theme/domain transition rule (a feature roll can shift the site into a
+   new theme or domain mid-delve) is a model for sites that evolve as you
+   explore — a derelict that turns out to be infested, a cavern that opens
+   into ancient ruins. A narrator could use the same idea to keep long
+   explorations from feeling static.
+
+6. **Yet another truth schema.** Delve uses the *original Ironsworn*
+   truths (a third distinct set, alongside Starforged's 14 and Sundered
+   Isles' 11). This reinforces the earlier observation that "setting
+   truths" are always game-specific. A module's constitutional-axiom
+   injection is per-game, not universal across the Ironsworn line. Delve
+   is unlikely to be directly relevant here since the module is
+   Starforged-based, but it confirms the pattern.
+
+7. **Threats and items-of-power are optional structured subsystems.** If
+   the module ever wants more structure than Starforged's bare campaign
+   clocks, Delve's Threats system is a more elaborate model. Likely out of
+   scope, but noted as prior art within the same design family.
+
+8. **The whole supplement is "optional layered onto core."** Like Sundered
+   Isles, Delve is additive — it plugs into the base engine without
+   replacing it. The architectural lesson the module already embodies
+   (setting and subsystems are separable from the core resolution engine)
+   holds across the entire Ironsworn product line.

--- a/docs/rules-reference/sundered-isles-guidebook-summary.md
+++ b/docs/rules-reference/sundered-isles-guidebook-summary.md
@@ -1,0 +1,431 @@
+# Ironsworn: Sundered Isles — Guidebook Summary
+
+A section-by-section paraphrased summary of the Sundered Isles guidebook,
+intended as design context for Claude Code. The summary covers the
+setting, the subsystems that differ from or extend Starforged, the
+design intent, and how the pieces interrelate. It deliberately omits the
+oracle tables (Section 3) and the detailed move reference (Section 4),
+since those are data the foundry-ironsworn system exposes, and omits the
+book's prose, art, and verbatim asset/move text.
+
+**Source:** Ironsworn: Sundered Isles Guidebook (Shawn Tomkin, 2024),
+digital edition. Text licensed CC BY-NC-SA 4.0.
+
+**Critical framing:** Sundered Isles is **not a standalone game**. It is
+an expansion for Starforged. It assumes the Starforged rulebook and reuses
+the entire Starforged engine — the action roll, momentum, progress tracks,
+condition meters, assets, oracles, and the move framework are all
+identical. Sundered Isles changes the *setting* (fantasy age-of-sail
+instead of space opera), adds *new subsystems* (ships, crews, naval
+combat, optional wealth), introduces *new assets and oracles*, and makes
+*minor wording changes* to some Starforged moves to fit the nautical
+theme. When this summary describes a mechanic without saying it's new,
+assume it's inherited from Starforged unchanged.
+
+**What this is for:** When Claude Code reasons about supporting Sundered
+Isles play, or about narrator behaviour in a seafaring campaign, or about
+how the module's subsystems would need to extend to handle ships and
+crews, this is the reference. For verbatim rules, asset cards, oracle
+tables, or move text, consult the actual guidebook or the
+foundry-ironsworn system data.
+
+---
+
+## The setting at a glance
+
+The Sundered Isles is a vast equatorial realm of thousands of scattered
+islands, set in an age of sail. It sits a long voyage away from a
+continental domain on the far side of the world. The default tone is
+fantasy seafaring: wooden ships, cannons, mariners and marauders, rebels
+and empires, myth and magic. As with Starforged, the specific nature of
+the world is decided by the players during campaign setup — it can mirror
+a real-world age of sail, or lean into wondrous machines, powerful magic,
+titanic beasts, and curses.
+
+Notably, the setting is flexible enough to support three "realms" chosen
+at setup: the default **Seafaring Realm** (ocean and islands), an
+**Overland Realm** variant, and even a **Starfaring Realm** that maps the
+Sundered Isles structure back onto a Starforged-style space campaign with
+re-themed assets. The same rules serve all three.
+
+### Two moons, the tides, and the Twin Fates
+Two moons — **Cinder** (red) and **Wraith** (silver-blue) — orbit the
+world and create dramatic, erratic tides that vary by hour, day, and
+season. Tides are the rhythm of the isles and a constant navigational
+hazard. Islanders read omens in which moon rises first or shines
+brightest, but rarely agree on meanings.
+
+An optional flavour rule treats the two challenge dice as the **Twin
+Fates**: one die is Cinder (hot — aggressive, passionate, physical), the
+other Wraith (cool — careful, mysterious, cunning). The higher die can
+add nuance to a result or act as a standalone oracle. This is purely
+optional colour layered onto the standard dice mechanic.
+
+### Three regions
+The isles divide into three broad regions, which function like Starforged's
+region tiers (escalating danger and isolation):
+
+- **The Myriads** — fair weather, charted passages, bustling ports;
+  pirates and privateers hunt easy prey. The "safe" region.
+- **The Margins** — greater distances, fickle weather; skill and luck
+  matter. The middle region.
+- **The Reaches** — unpredictable seas, isolated isles, profound
+  mysteries and dangers. The frontier, craved by those seeking freedom.
+
+Each region is separated from the next by open water; crossing between
+them ("crossing the bounds") is itself a significant undertaking.
+
+---
+
+## Section 1 — Adventures Among the Isles
+
+This section is setting reference plus the new gameplay subsystems. It's
+the meat of what distinguishes Sundered Isles mechanically.
+
+### Your character
+Character creation is the Starforged process. The difference is the asset
+pool: Sundered Isles ships with dozens of new assets themed for fantasy
+seafaring, and the player builds a curated deck combining new Sundered
+Isles assets with a selection of core Starforged assets.
+
+New asset categories include:
+
+- **Command vehicle: SAILING SHIP** — every seafaring character has a ship
+- **Modules** for ships — ARMORED PROW, LUCKY FIGUREHEAD, IMPROVED HOLD,
+  SUBMERSIBLE MODE, HARPOON CANNON, etc.
+- **Support vehicles** — LONGBOAT, DIVING BELL, FLYING MACHINE, CAPTAIN'S
+  BOAT
+- **Paths** for the setting — DUELIST, MUSKETEER, PIRATE CAPTAIN,
+  SWASHBUCKLER, NECROMANCER, WINDBINDER, SHIPWRIGHT, and many more
+- **Companions** — JUNGLE CAT, PARROT, ALBATROSS, MONKEY, and fantastic
+  ones like DRAGON and THE KRAKEN
+- **Deeds** (legacy markers) — FLEET COMMANDER, UNDEAD, OATHBREAKER,
+  REVENANT, etc.
+
+Some Sundered Isles assets are re-themed renames of Starforged
+counterparts (e.g., PEDDLER replaces the Starforged TRADER). The deck is a
+recommendation, not a mandate; the rulebook stresses avoiding overlap so
+each player has distinct resources, abilities, and roles. Assets are
+"stackable" and the "rule of 3" caution from Starforged applies — watch
+for combinations that make success a foregone conclusion.
+
+The player picks **two path assets** as the foundation of the character
+concept, exactly as in Starforged.
+
+### Your ship
+The ship is treated as a first-class aspect of the character. Three tiers:
+
+- **SAILING SHIP** — the starting command vehicle, or an incidental/
+  temporary vessel. Relatively fragile (mechanically and narratively); a
+  player may lose one and claim another over the campaign. Can be promoted
+  to FLAGSHIP.
+- **FLAGSHIP** — the upgraded command vehicle, purchased with experience
+  via Advance (or gained as a gift, prize, salvage, or promotion of an
+  incidental ship). Max integrity 5; can be marked **battered** or
+  **cursed** as debilities to avoid a decisive Withstand Damage roll. Has
+  up to 5 **hold** (acting as ship-wide supply), can equip modules and
+  support vehicles, and grants narrative perks (a distinctive flag that
+  gives momentum when hoisted dramatically).
+- All command vehicles share the same mechanical attributes regardless of
+  whether they're a sloop, frigate, or titan. The *nature* of the ship
+  affects challenge ranks and how actions and outcomes are interpreted,
+  plus whatever modules are attached.
+
+**Modules** attach to the FLAGSHIP and give conditional bonuses (e.g.,
+ARMORED PROW adds bonuses when ramming or sailing through obstacles). A
+module can be marked **broken** when the ship takes a miss on Withstand
+Damage, to offset danger; a broken module can't be used until Repaired.
+
+**Support vehicles** are secondary craft launched from the main ship, each
+with its own integrity meter, marked **battered** and **Repaired** like
+any vehicle.
+
+### Command and crews
+A commanded ship needs a crew. Critically, **the crew has no mechanical
+detail** — they're abstracted into the character's own actions and the
+ship's inherent capabilities. The moves a player makes represent both
+their individual exploits and the actions of the crew and ship under their
+leadership.
+
+Key design points:
+
+- In solo play with a ship, the character is the captain. With allies, one
+  is captain (unless the group envisions communal leadership). Non-imperial
+  vessels rarely have strict chains of command.
+- Players take fitting duties — quartermaster, carpenter, gunner, surgeon,
+  cook, navigator, or fantastic roles (soothsayer, dragon-wrangler,
+  ghost-hunter) — but are broadly capable and wear several hats.
+- Most crew are background extras. Notable crewmembers can be named and
+  given a characteristic; one might become a specialist via the COHORT
+  asset.
+- **Crew mood and condition matter narratively** — full complement vs.
+  casualties, well-provisioned vs. discontent, even brewing mutiny. These
+  provide context for challenge ranks.
+
+**Crew-related assets** add optional mechanical depth:
+
+- **CREW COMMANDER** introduces a new condition meter, **command**
+  (crew strength, loyalty, morale; max starts at 4, upgradable to 6).
+  Command can be spent to improve outcomes or offset costs; at 0 it counts
+  as an impact. Restored by rewarding the crew (treasure share, respite).
+- **PIRATE CAPTAIN**, **COHORT**, **FLEET COMMANDER** — further leadership
+  and crew-relationship assets, usable in Sundered Isles or in a
+  Starforged campaign with a crewed starship.
+
+### Supply at sea
+This is a meaningful extension of Starforged's single supply meter. With a
+ship, supply splits into **two meters**:
+
+- **Equipped supply** — the personal supply meter from Starforged;
+  provisions and equipment carried on your person
+- **Hold supply** — the ship's stores (up to 5 on a FLAGSHIP); provisions
+  and gear at the ship-wide level
+
+Each is tracked separately and each can independently trigger the
+**unprepared** impact at 0. If both hit 0, the second unprepared is an
+extra impact. Resupply clears one instance of unprepared per action.
+
+The Sundered Isles **Resupply** move adds an option to "gear up from your
+ship's stores" — drawing hold supply to bolster equipped supply, rolling
++supply (hold) and resolving as a normal move (strong hit: free transfer;
+weak hit: transfer but Sacrifice Resources; miss: no transfer and a
+complication). If the ship is lost, hold supply is lost with it (no
+unprepared marked, but no hold supply until a new ship is gained).
+
+Supply remains abstracted — not counting individual barrels — but the
+rulebook encourages thinking in terms of specific resources (fresh water,
+shot, grog) to give perils and opportunities texture. The design intent is
+explicit: keep pressure on, depict scarcity, don't go easy.
+
+### Wealth and treasure (OPTIONAL subsystem)
+By default, Starforged and Sundered Isles don't track money — wealth is
+abstracted into supply and legacy progression. Sundered Isles adds an
+**optional** wealth system for campaigns that want ships' upkeep and
+plunder to drive the story.
+
+Components:
+
+- **Treasury** — a reserve of money, goods, and valuables, distinct from
+  supply. Used to maintain crew and ship, make purchases, grant favours,
+  pay debts.
+- **Ledger** — an itemized inventory of the treasury. Each acquisition
+  (trade goods, payment, gold, a captured ship) is assigned a **value 1–5**
+  (mundane to wondrous). Items are spent down circle by circle.
+- **Spending wealth** doesn't add mechanical bonuses to moves, and usually
+  isn't an excuse to skip a move. Instead it unlocks narrative options
+  (commissioning repairs "at a facility," hiring a guide to Set a Course
+  instead of Undertake an Expedition, bribing an official as part of a
+  Compel). It can also help resolve a costly outcome (sweetening a bribe
+  after a weak hit).
+- **Converting wealth** — illiquid items (a captured frigate) can be
+  converted to spendable resources, typically losing one value step. Not
+  all resources are spendable everywhere; Ask the Oracle if unsure.
+- **Upkeep** — an ongoing cost (1–5 by fleet size) for maintaining ships
+  and crew, typically paid during Sojourn. Failing to pay upkeep breeds
+  crew discontent and ship disrepair, pushing the player toward jobs,
+  treasure hunts, or plundering imperial targets.
+- **Cursed riches** — the cursed die can reveal uncanny aspects of
+  treasure (foul magic, hauntings). Greed is framed as a corrupting force.
+
+Design guidance: wealth-tracking is for the early "scramble to survive"
+phase. Once it becomes a foregone conclusion, the rulebook explicitly says
+to drop it. A large hoard or wondrous artifact is meant to *upend* the
+campaign — generating questions of secrecy, rival hunters, and how to use
+it toward the iron vows.
+
+### Navigating the isles
+Sea and overland journeys use Starforged's **exploration moves** (Set a
+Course, Undertake an Expedition, etc.). Sundered Isles adds nautical
+framing:
+
+- Sea travel is never a straight line — meandering routes around uncharted
+  islets, erratic moon-driven tides, hull-breaching reefs, sudden weather,
+  and possibly hostile sails on the horizon.
+- The decision tree for a voyage:
+  - Short distance, safe water → no move
+  - Know the way but risk exists → **Set a Course** (single roll)
+  - Perilous unknown waters → set a rank and **Undertake an Expedition**
+    per segment, then **Finish the Expedition** when the destination is in
+    sight
+- **Crossing the bounds** between regions is a notable expedition in its
+  own right.
+
+### Naval encounters (phased ship combat)
+This is the most structurally distinct combat content. Ship-to-ship
+combat is organized into **phases**, layered on top of Starforged's
+existing combat moves (Enter the Fray, Gain Ground, React Under Fire,
+Strike, Clash, Take Decisive Action, Battle):
+
+1. **Approach phase** — the maneuvering before weapons range. Resolved
+   with a roll that sets the difficulty of the engagement (success lowers
+   the objective rank, failure raises it). Skipped if the fight starts at
+   cannon range, if surprise removes it, or if the outcome isn't in doubt.
+2. **Engagement phase** — "Fire!" Combat at weapons range, opened with
+   **Enter the Fray**. The player sets an **engagement objective** (escape,
+   sink the foe, or board the enemy) — which may differ from the overall
+   objective of the fight. Each objective gets a challenge rank
+   (formidable as baseline; extreme if outmatched; dangerous if superior).
+   A **tension clock** (4 segments typical, 6 for complex fights) can
+   represent the enemy's opposing goal or an external looming threat (a
+   building maelstrom). Combat proceeds with the standard in-control /
+   in-a-bad-spot framing, mapping ship actions to Starforged combat moves
+   (maneuver the ship → Gain Ground or React Under Fire; damage control →
+   Repair or React Under Fire; tend wounded → Heal; etc.).
+3. **Boarding phase** (implied by the engagement objective "board") —
+   where higher-level objectives like defeating an enemy captain in single
+   combat get resolved.
+
+The key design idea: naval combat reuses the entire Starforged combat
+engine, adding the phase structure, the engagement-objective concept, and
+the ship-action-to-move mapping table as scaffolding. Multiple foes can be
+bundled into one objective (raising its rank), and noteworthy obstacles
+can become their own objectives, including objectives an ally pursues
+independently.
+
+### Interludes
+A pacing tool (extending Starforged's session/scene rhythm) for the quiet
+moments between action — time aboard ship, in port, or ashore for rest,
+relationships, and reflection. The narrative breathing room between
+perils.
+
+### Factions of the isles
+Setting reference for the powers contesting the isles — imperial powers,
+pirate confederations, rebel movements, island communities, and stranger
+forces. Factions are introduced during campaign setup as an exercise
+informed by the chosen truths, and provide the backdrop of conflict
+(espionage, open warfare, the central struggle against imperial tyranny).
+
+### Beasts of the isles
+Setting reference for the creatures of the realm — from mundane sea life
+to krakens, ghost ships, and supernatural horrors. These function like
+Starforged's NPCs: minimal mechanical footprint (a rank plus fiction
+prompts), with the player rolling against the creature's rank. The
+foundry-ironsworn system exposes specific creature data; this summary
+doesn't duplicate it.
+
+---
+
+## Section 2 — Getting Underway
+
+The campaign-launch exercises, mirroring Starforged's structure: choose
+truths, introduce factions, build your asset deck, create your character
+and ship, and set the campaign in motion. Allow ~30–45 minutes for the
+truths exercise.
+
+### Choose your truths — 11 categories
+Like Starforged's 14 truths, these are the constitutional axioms of the
+campaign world, chosen at setup and binding thereafter. **The categories
+differ from Starforged's** — they're seafaring-themed. The 11 categories:
+
+| Category | What it defines |
+|---|---|
+| Sundering | The cataclysm/history that shattered or shaped the isles |
+| Relics | What ancient artifacts and ruins exist, and their nature |
+| Modern Era | The current state of technology and society |
+| Iron Vows | Why iron is sacred and how vows work in this world |
+| Navigation | How sailing, charts, and wayfinding work; the role of tides |
+| Empires | The imperial powers and their reach into the isles |
+| Piracy | The nature and prevalence of piracy |
+| Religion | What people believe |
+| Magic | Whether supernatural power is real, and its shape |
+| Beasts | What creatures inhabit the seas and islands |
+| Horrors | What lurks in the dark; the supernatural-horror layer |
+
+Each is chosen the same three ways as Starforged: pick one of three
+defaults, roll for it, or customize/craft your own. Each category also
+suggests fitting character assets (person icon) and potential factions
+(flag icon) to seed the later exercises. Quest starters are provided per
+category to fuel opening vows.
+
+The realm choice (Seafaring / Overland / Starfaring) interacts with the
+truths — e.g., a Starfaring Realm re-themes technological assets as
+aether-powered tech, or magic as a setting force.
+
+### The remaining launch exercises
+Following the truths, the launch sequence covers introducing factions
+(informed by the truths), assembling the curated asset deck (using the
+asset guide), creating the character and choosing two paths, establishing
+the ship and how command was gained (SAILING SHIP by default, or FLAGSHIP
+for a more seasoned commander), and setting the campaign in motion with an
+inciting mission or imminent danger — then "play to see what happens,"
+exactly as in Starforged.
+
+---
+
+## Sections 3 and 4 (summarized briefly)
+
+### Section 3 — Oracles
+A large array of oracle tables specific to the Sundered Isles, parallel to
+Starforged's oracle chapter. Includes the **cursed die** mechanic (a
+special-colour D10 rolled alongside oracle dice; a result on it reveals
+cursed, uncanny, or ill-fated aspects). Tables cover isle and region
+features, ships and sails, ports and settlements, characters and crews,
+factions, beasts, relics and ruins, treasure, weather and tides, and
+naval-encounter specifics. These are data; the foundry-ironsworn system
+exposes them and this summary doesn't reproduce them.
+
+### Section 4 — Moves Reference
+The Sundered Isles moves are the **Starforged moves with minor wording
+changes** to fit the nautical setting (e.g., Resupply's "gear up from your
+ship's stores" option, Withstand Damage applied to ships, exploration
+moves framed for sea travel). The mechanical skeleton is unchanged; the
+fiction-facing language is re-themed. Includes the recommended **session
+moves / safety tools** (page 237) carried over from Starforged.
+
+---
+
+## Implications for module design
+
+Observations relevant to whether and how the module would extend to
+Sundered Isles:
+
+1. **Sundered Isles is an engine re-skin plus subsystems, not a new
+   ruleset.** Any module built on the Starforged move/oracle engine
+   already handles the core of Sundered Isles play. Supporting it is
+   primarily a matter of (a) adding the new assets and oracles as data,
+   (b) handling the wording-changed moves, and (c) optionally modeling the
+   new subsystems (ships, two-meter supply, command, treasury, naval
+   phases).
+
+2. **The truths are a different set.** If the module injects World Truths
+   into the narrator context (as it does for Starforged's 14), a Sundered
+   Isles campaign needs the 11 seafaring categories instead. The narrator's
+   constitutional-axiom layer is setting-specific. A module supporting both
+   settings needs to know which truth schema is active.
+
+3. **Two-meter supply breaks an assumption.** Any module logic that treats
+   "supply" as a single value would need to branch for Sundered Isles'
+   equipped-vs-hold split, including the dual-unprepared rule and the
+   ship-loss case.
+
+4. **Ships and crews are mostly fiction, lightly mechanical.** The crew has
+   no mechanical detail; the ship is a vehicle asset with integrity. The
+   narrator's fact-continuity concerns (see fact-continuity scope) extend
+   naturally — a ship is a persistent entity with truths (its name, its
+   nature, its flag) and state (current integrity, broken modules, crew
+   mood). The COHORT/CREW COMMANDER command meter is the main new
+   mechanical surface.
+
+5. **Naval combat is phased but reuses combat moves.** A module that
+   surfaces combat moves already has the primitives. The phase structure
+   (approach → engagement → boarding) and the engagement-objective concept
+   are scaffolding the narrator could be prompted to manage, rather than
+   new mechanics requiring new resolution code.
+
+6. **Wealth is optional and toggle-able by design.** If the module ever
+   models treasury/ledger/upkeep, it should be an opt-in subsystem
+   mirroring the rulebook's own stance — on for the early survival phase,
+   droppable once it becomes busywork. This maps cleanly to a per-campaign
+   setting.
+
+7. **The narrator's setting voice changes.** A Sundered Isles narrator
+   draws on age-of-sail imagery, the two moons, the tides, imperial
+   tyranny, and seafaring peril rather than space-opera tropes. If the
+   module ever supports both, the narrator's tonal/setting context is
+   another setting-specific injection alongside the truths.
+
+8. **Three-realm flexibility is a deeper fork.** The Starfaring Realm
+   variant means Sundered Isles structures can be layered back onto a
+   space campaign. For a module's purposes this is an edge case, but it
+   underlines that "setting" and "engine" are cleanly separable in this
+   game line — which is the same separation the module already relies on.

--- a/rules/game-rules.md
+++ b/rules/game-rules.md
@@ -23,6 +23,12 @@ without the noise of the full rulebook prose.
 | [`docs/rules-reference/sundered-isles-playkit-rules.md`](../docs/rules-reference/sundered-isles-playkit-rules.md) | Rules reference for the **Sundered Isles** expansion (Tomkin 2024) — every move, clock, embedded table, worksheet, and safety tool, plus a Part 2 delta against Starforged and a Part 3 implementation-status / data-source note. | Only when a task explicitly concerns Sundered Isles. **Sundered Isles is not implemented** in the Companion (Starforged only); this is reference for potential future scoping, and a pointer to the SI data already vendored in `foundry-ironsworn`. |
 | [`docs/rules-reference/sundered-isles-guidebook-summary.md`](../docs/rules-reference/sundered-isles-guidebook-summary.md) | Section-by-section paraphrased summary of the **Sundered Isles** guidebook (Tomkin 2024) — setting, the subsystems that differ from or extend Starforged (ships, crews, two-meter supply, optional wealth, phased naval combat, the 11 seafaring truths), design intent, and an "Implications for module design" section. The expansion analogue of `rulebook-summary.md`. | Before reasoning about Sundered Isles narrator behaviour, seafaring subsystems, or how the module would extend to ships/crews. Same caveat: SI is not implemented in the Companion. |
 
+### Supplement: Ironsworn: Delve (original Ironsworn)
+
+| Doc | What it covers | When to read |
+|-----|---------------|--------------|
+| [`docs/rules-reference/delve-rulebook-summary.md`](../docs/rules-reference/delve-rulebook-summary.md) | Chapter-by-chapter summary of **Ironsworn: Delve** (Tomkin 2020) — the site-delving system (themes, domains, the denizen matrix, risk zones, the Delve-the-Depths loop), its seven moves, the optional Threats/Items subsystems, and design intent. | Rarely. Delve is a supplement for the **original Ironsworn**, *not* a Starforged expansion, and is **not implemented** in the Companion. Read it for design context only — it is the ancestor of Starforged's expedition moves, and a source of reusable location-generation abstractions (themes/domains, denizen matrix, risk zones) should the module ever want richer procedural sites. |
+
 These docs are about **the game**; they are not a substitute for reading
 the foundry-ironsworn source when touching Actor / Item schemas (see
 `rules/foundry-ironsworn.md`), or for fetching Foundry API docs when

--- a/rules/game-rules.md
+++ b/rules/game-rules.md
@@ -21,6 +21,7 @@ without the noise of the full rulebook prose.
 | Doc | What it covers | When to read |
 |-----|---------------|--------------|
 | [`docs/rules-reference/sundered-isles-playkit-rules.md`](../docs/rules-reference/sundered-isles-playkit-rules.md) | Rules reference for the **Sundered Isles** expansion (Tomkin 2024) — every move, clock, embedded table, worksheet, and safety tool, plus a Part 2 delta against Starforged and a Part 3 implementation-status / data-source note. | Only when a task explicitly concerns Sundered Isles. **Sundered Isles is not implemented** in the Companion (Starforged only); this is reference for potential future scoping, and a pointer to the SI data already vendored in `foundry-ironsworn`. |
+| [`docs/rules-reference/sundered-isles-guidebook-summary.md`](../docs/rules-reference/sundered-isles-guidebook-summary.md) | Section-by-section paraphrased summary of the **Sundered Isles** guidebook (Tomkin 2024) — setting, the subsystems that differ from or extend Starforged (ships, crews, two-meter supply, optional wealth, phased naval combat, the 11 seafaring truths), design intent, and an "Implications for module design" section. The expansion analogue of `rulebook-summary.md`. | Before reasoning about Sundered Isles narrator behaviour, seafaring subsystems, or how the module would extend to ships/crews. Same caveat: SI is not implemented in the Companion. |
 
 These docs are about **the game**; they are not a substitute for reading
 the foundry-ironsworn source when touching Actor / Item schemas (see


### PR DESCRIPTION
## Initiating prompts

> Great. Here is a summary of the SI expansion rules as well. Can you please add it next to the SF rules summary? *(Sundered Isles guidebook summary `.md` attached.)*

> Please add the delve summary as well *(Ironsworn: Delve summary `.md` attached.)*

---

## Summary

Adds two maintainer-supplied rules-reference summaries to `docs/rules-reference/`, beside the Starforged `rulebook-summary.md`. Both were added **verbatim** and cross-linked from `rules/game-rules.md`.

| File | Change |
|---|---|
| `docs/rules-reference/sundered-isles-guidebook-summary.md` *(new)* | Section-by-section summary of the **Sundered Isles** guidebook (Tomkin 2024): seafaring setting; the subsystems that extend Starforged (ships, crews & command meter, two-meter supply, optional wealth/upkeep, phased naval combat, the 11 seafaring truths); design intent; implications for module design. The expansion analogue of `rulebook-summary.md`. |
| `docs/rules-reference/delve-rulebook-summary.md` *(new)* | Chapter-by-chapter summary of **Ironsworn: Delve** (Tomkin 2020): the site-delving system (themes, domains, denizen matrix, risk zones, the Delve-the-Depths loop), its seven moves, optional Threats/Items subsystems, and design intent. |
| `rules/game-rules.md` | Cross-links both — Sundered Isles under the existing "Expansion" heading; Delve under a separate "Supplement" heading, framed as **original-Ironsworn** design context (not a Starforged expansion). |

This complements the SI play-kit rules reference from #233. Together the rules-reference folder now mirrors the Starforged docs across the Ironsworn line: Starforged (rulebook + play kit), Sundered Isles (guidebook + play kit), and Delve (rulebook summary).

## Notes

- **Docs-only** — no code, tests, or user-facing changelog touched.
- Both Sundered Isles and Delve remain **not implemented** in the Companion (Starforged only); these are reference docs for design context / potential future scoping. The Delve cross-link is explicitly framed as original-Ironsworn prior art, distinct from the SI expansion.

## Test plan

- [x] Docs-only; no behaviour change. CI (Lint & Test / Quench) unaffected.

🤖 Generated with Claude Code