### PR TITLE
ci: stop deploying Help Pages on release (redundant + failing)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,8 +7,13 @@ on:
       - 'src/help/helpJournal.js'
       - 'scripts/build-help-site.mjs'
       - '.github/workflows/pages.yml'
-  release:
-    types: [published]
+  # NOT triggered on `release: published`. The help site renders
+  # CONTENT_VERSION from src/help/helpJournal.js (never module.json), so a
+  # release — which only bumps module.json — changes nothing here; the site is
+  # already current from the merge-to-main deploy above. A release deploy was
+  # also failing: it runs in the tag ref context, which the github-pages
+  # environment's deployment-branch protection rejects. Use workflow_dispatch
+  # to redeploy manually if ever needed.
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Initiating prompt

> Mild annoyance: releasing a version always results in a failed deployment of the help pages, even though PRs result in successful ones.

## Diagnosis

`.github/workflows/pages.yml` ("Deploy Help Pages") triggers on **both** push-to-main and `release: published`. Confirmed from the Actions history: every **release**-triggered run fails (v1.7.28, v1.7.27, …), and within those runs the **build** job succeeds — only the **"Deploy to GitHub Pages"** job fails. Push-to-main runs succeed.

That asymmetry is the `github-pages` **environment's deployment-branch protection**: a release run executes in the **tag** ref context (`refs/tags/vX.Y.Z`), which the environment doesn't permit, so `actions/deploy-pages` is rejected. (The "successful ones" you see on PRs are the separate build-only **Build Help Site** check in `ci.yml`, which never deploys.)

It's also **redundant**: the help site renders `CONTENT_VERSION` from `src/help/helpJournal.js` and never reads `module.json`, so a release — which only bumps `module.json` — changes nothing on the site. It's already current from the merge-to-main deploy.

## Fix

Drop the `release: published` trigger. The site still deploys on every real content change (push-to-main touching `helpJournal.js` or the build script), and `workflow_dispatch` remains for manual redeploys. No more failed deploy on release.

**Alternative (not taken):** allow tags in the `github-pages` environment's deployment-branch rule (repo setting) — that would make the redundant release deploy *succeed* instead of fail. Removing the redundant trigger is cleaner; happy to switch to the env-setting approach instead if you'd rather releases still trigger a (no-op) deploy.

## Test plan

- [x] CI-only change; the next release will no longer run a Pages deploy. Help-site content continues to deploy from `main` as before. (Not user-facing — no CHANGELOG/help entry.)

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_011nD9TZKAeTWpfVXcFVgU63)_