### PR TITLE
test: de-flake setup.js randomID (fixed-length base-62 ids)

### DIFF
--- a/tests/setup.js
+++ b/tests/setup.js
@@ -85,7 +85,19 @@ global.Hooks = {
 
 global.foundry = {
   utils: {
-    randomID: () => Math.random().toString(36).slice(2, 10),
+    // Mirror Foundry's real foundry.utils.randomID: a fixed-length (default 16)
+    // base-62 string. The previous `Math.random().toString(36).slice(2, 10)`
+    // produced a VARIABLE-length id (≤8 chars, occasionally fewer when the
+    // base-36 expansion was short), which intermittently broke tests that assume
+    // ids are long and unique — e.g. factContinuity's strikeTruth "6-char prefix
+    // is unique" check flaked in CI. A fixed-length, well-distributed id removes
+    // that flake (6-char prefix collisions are ~1/62^6).
+    randomID: (length = 16) => {
+      const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+      let id = "";
+      for (let i = 0; i < length; i += 1) id += chars[Math.floor(Math.random() * chars.length)];
+      return id;
+    },
     hasProperty: (obj, key) => {
       const parts = key.split('.');
       let cur = obj;


### PR DESCRIPTION
## Initiating prompt

> Please do the infra PR

(The "infra PR" = de-flaking the shared test-infra `randomID` mock flagged after #243/#244.)

## Problem

`tests/setup.js`'s `foundry.utils.randomID` mock was `() => Math.random().toString(36).slice(2, 10)` — a **variable-length** string (≤8 chars, and occasionally fewer when the base-36 expansion was short). Tests that assume Foundry-style long, unique ids flaked on it. Concretely, `factContinuityCorrections`'s `strikeTruth` *"strikes by 4+ char prefix when unique"* test slices a 6-char prefix and expects a unique match; with a too-short/low-entropy id the prefix wasn't unique (or present), so it intermittently failed in CI — it passed locally and Quench passed on the same SHA, and a plain re-run went green (the tell-tale of a flake). It blocked #243 once.

## Fix

Replace the mock with one that mirrors Foundry's **real** `randomID`: a fixed-length (default 16) base-62 string. Fixed length + good distribution removes the variable-length root cause; 6-char prefix collisions are now ~1/62⁶ (negligible). No production code changes — test infra only.

## Verification
- Full suite green: **2796 passing**, 0 lint errors.
- The previously-flaky `factContinuityCorrections` test passed **5/5** repeated runs locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nD9TZKAeTWpfVXcFVgU63

---
_Generated by [Claude Code](https://claude.ai/code/session_011nD9TZKAeTWpfVXcFVgU63)_