### PR TITLE
docs: faction lifecycle + narrator-consistency audits — eight verified defects

### DIFF
--- a/docs/flows/faction-flow.md
+++ b/docs/flows/faction-flow.md
@@ -1,0 +1,124 @@
+# Faction lifecycle flow — as implemented
+
+How factions are born, where their state lives, what updates it, and what the
+narrator actually sees — verified against source (v1.7.30 cycle). Sibling
+docs: `narrator-context-flow.md`, `character-detail-flow.md`,
+`connection-flow.md`.
+
+Prompted by: "I'd like the same treatment applied to faction lifecycle".
+Findings are tagged **WRONG-DETAIL** / **LOSE-PLOT** / **INVENT-RISK** as in
+the sibling audits. §3 is the open defect ledger (fixes await direction).
+
+## 1. The two faction stores (and a half)
+
+**World Journal faction entries** (`src/world/worldJournal.js`): pages on
+"World Journal — Factions", flag `factionEntry`, shape
+`{ factionName, attitude, summary, … }` with `attitude ∈ hostile | neutral |
+allied | unknown` (`FACTION_ATTITUDES`). Written by
+`recordFactionIntelligence` — from the detection pass (new narrator-named
+factions are WJ-surfaced immediately, gated on `entityExistsForName`) and
+from `attitudeShift` state transitions. Read by `getFactionLandscape` (up to
+3, most recently updated) and `!journal faction` commands.
+
+**Faction entity records** (`src/entities/faction.js`): journal-entry-backed
+records with the full Starforged shape — type/subtype, influence,
+dominion/leadership, `projects[]`, `rumors[]`, quirk, and
+`relationship ∈ antagonistic | apathetic | distrustful | does_business |
+open_alliance | temporary_alliance | warring | unknown`. Created by the
+sector generator and by draft-card confirmation (`ENTITY_CREATORS.faction →
+createFaction` with name + description only — no oracles rolled, unlike
+connections). Read by the relevance resolver → ENTITIES IN SCENE cards
+(`formatEntityCard` has a faction field table including `relationship`) and
+the entity panel (which can edit `relationship` manually).
+
+**The half-store:** `sector.faction` — a bare control-faction name string on
+the active sector, rendered in the ACTIVE SECTOR block. Static, name-only.
+
+## 2. What the narrator actually sees
+
+- **Matched entity cards only.** A faction reaches the narrator system
+  prompt solely when the relevance resolver matches its name (or the frame
+  union carries it) — rendering the *entity record*: type, influence,
+  `relationship` stance, latest project, quirk, description, generative-tier
+  details.
+- **The WJ faction landscape reaches the narrator nowhere.** Its only
+  consumers are the assembler's FACTION LANDSCAPE packet section — see §3
+  defect 1 — and `describeWorldJournalState`, which feeds current attitudes
+  to the *detection Haiku* so it can classify transitions. The detector
+  knows the political landscape; the narrator does not.
+- **Generative tier works.** The paced/move tier-update pass is
+  type-agnostic (`runNarrationTierUpdate` maps matched ids + types), so a
+  matched faction accrues salience-gated development details like any other
+  entity — the one narrative write the record receives.
+
+## 3. Verified defects (open — awaiting direction; see `known-issues.md`)
+
+1. **FACTION-PACKET-DEAD** (LOSE-PLOT — root cause, wider than factions):
+   `assembleContextPacket` builds a 17-section packet — FACTION LANDSCAPE,
+   immediate/looming threats, confirmed + asserted WJ lore, recent
+   discoveries, session notes, lore recap, RECENT ORACLES, progress tracks,
+   character state — and every callsite (move pipeline `index.js:1666`,
+   burn-momentum re-narration, improve-result re-narration) passes it to
+   `narrateResolution(resolution, contextPacket, …)` whose `contextPacket`
+   parameter is **never read**. The interpreter doesn't take it either
+   (`interpretMove` assembles its own inputs). The packet subsystem is dead
+   on every live path — a Loremaster-era conduit orphaned when narration
+   moved to `buildNarratorSystemPrompt`, surviving because unit tests
+   exercise the builder but nothing tests the composition (the exact
+   CHAR-PC-BLOCK-STARVED failure shape). Consequence for factions: **the
+   living political state (WJ attitudes) is invisible to the narrator**, as
+   are WJ threats and non-migrated lore.
+2. **FACTION-DUAL-STORE** (WRONG-DETAIL): a narrator-named faction is
+   WJ-surfaced immediately (good — durable home) *and* queued as a draft;
+   confirming the draft creates the entity record with
+   `relationship: "unknown"` — and nothing merges or retires the WJ entry.
+   Two records for the same faction, two vocabularies (`attitude` 4-value vs
+   `relationship` 8-value), no reconciliation, free to diverge.
+3. **FACTION-ATTITUDE-SPLIT-BRAIN** (WRONG-DETAIL): `attitudeShift`
+   transitions write the WJ store unconditionally — the transitions loop in
+   `routeWorldJournalResults` has no `entityExistsForName` gate (the
+   new-faction loop does) — while **no narrative path ever updates
+   `record.relationship`** (`updateFaction` has zero callers outside the
+   file). Net: the story's attitude changes land in the store the narrator
+   can't see (defect 1), and the store the narrator *can* see (the entity
+   card) shows a stance frozen at confirm time. The narrator can court a
+   faction the fiction says is now `warring`.
+4. **FACTION-RECORD-WRITE-ONCE** (LOSE-PLOT): `updateFaction`, `addRumor`,
+   `setProject`, and `setSceneRelevant` are exported and never called;
+   `active` is never flipped and `listFactions` doesn't filter on it
+   anyway; draft-confirmed factions skip oracle seeding entirely (name +
+   description only — no type/influence/quirk, unlike connections'
+   `seedConnectionActor`). Beyond the generative tier and manual panel
+   edits, a faction record is frozen at creation: projects and rumors are
+   dead fields the narrator sees as eternally current.
+5. **FACTION-DETECTOR-ONLY-CONTEXT** (INVENT-RISK): the detection Haiku
+   receives the WJ attitude landscape (`describeWorldJournalState`) but the
+   narrator generating the prose does not — so transitions are *classified*
+   against a political map the *author* of the prose never saw. The
+   narrator can invent a faction stance that contradicts the recorded
+   attitude, and the pipeline's answer is to record the contradiction as a
+   new shift rather than prevent it.
+
+## 4. Design-level exposure
+
+- **Faction stance has no single source of truth by design history**, not
+  decision: WJ `attitude` (narrative intelligence) and record
+  `relationship` (Starforged stance) genuinely mean different things, but
+  nothing documents which wins, maps one to the other, or updates either
+  from play. Any fix should pick a canonical home and mirror (the
+  connection record ↔ bond Item pattern).
+- **`sector.faction` is a third, name-only mention** — fine as flavor, but
+  if the control faction gains a record/WJ entry the three are never
+  linked.
+- **No faction lifecycle end**: no dissolution/absorption affordance
+  (`active` dormant). Low urgency; recorded for completeness.
+
+## 5. What held up under audit
+
+New narrator-named factions get an immediate durable WJ home (auto-surface,
+2026-06) instead of dying in an unconfirmed draft; the new-faction WJ loop
+correctly skips names that already have entity records; matched faction
+entity cards render the full record including stance and latest project;
+the generative tier accrues narrative development for matched factions;
+`!journal faction` gives the GM a manual attitude-correction path; and the
+entity panel can edit the record's stance directly.

--- a/docs/flows/narrator-consistency-flow.md
+++ b/docs/flows/narrator-consistency-flow.md
@@ -1,0 +1,119 @@
+# Narrator consistency flow — as implemented
+
+The consistency-check pipeline end to end: what triggers the audit, what it
+compares prose against, how a catch reaches the GM, and what the remedy
+affordances actually do — verified against source (v1.7.30 cycle). Sibling
+docs: `narrator-context-flow.md` (the ledger the audit defends),
+`character-detail-flow.md` (the RECORDED IDENTITIES section).
+
+Prompted by: "the same treatment applied to … narrator consistency" —
+scoped as the fact-continuity consistency-check pipeline (detection →
+review card → correction), plus the adjacent WJ lore-contradiction path.
+§3 is the open defect ledger (fixes await direction).
+
+## 1. Trigger and audit scope
+
+`applyNarratorSidecar` fires `runConsistencyCheck(prose, campaignState,
+{matchedEntityIds, currentLocationId, playerNarration})` on the **canonical
+GM only**, fire-and-forget (never blocks or delays the narration post), for
+every mode that applies a sidecar — all nine narrator paths. Gated on
+`factContinuity.consistencyCheck` (**default ON** since 2026-07; the
+unregistered-settings fallback stays false so unit tests never fire API
+calls).
+
+The audit prompt (`buildAuditPrompt`) compares prose against the FULL
+ledger block (`buildLedgerBlock` at `maxTokens: Infinity`) — SCENE FRAME,
+RECORDED IDENTITIES (PC + matched-NPC pronouns, 2026-07), TRUTHS, RETRACTED
+FACTS, STATE, SHIP POSITION — via one Haiku call (`claude-haiku-4-5`,
+`max_tokens: 250`, through `api-proxy.js`). Response kinds: `truth | state
+| frame | ship | retraction | identity`, each with confidence high/medium/
+low; parsing is fence-and-preamble tolerant and never throws.
+
+**Who passes matched entities:** the move path, `@scene`, and paced all
+pass `relevance/extras.matchedEntityIds` into the apply ctx, so the audit's
+entity-scoped ledger entries and matched-NPC identities are in scope on the
+three main prose paths. Oracle follow-ups build `extras.matchedEntityIds`
+but do **not** pass them (§3 defect 2); vignettes / vow swearing / inciting
+pass none (they have no player text and match nothing — harmless).
+
+## 2. From catch to correction
+
+- **High-confidence** contradictions dispatch
+  `applyStateTransition({entryType: "factContinuity", change:
+  "contradicted", …})` → `postContradictionNotification`: a GM-whispered
+  **◈ Narrative Review** card naming the subject and violated fact, with a
+  "Retract the offending fact" button. The card carries
+  `contradictedTruthId` + `matchedEntityIds` flags and co-marks
+  `narratorCard` purely to surface the render hook — the ring's defensive
+  excludes (`worldJournalContradiction`) keep it out of narrator memory.
+- The button opens the **Correct Active Scene Facts dialog**
+  (`openCorrectionDialog`), scoped to the card's matched entities + current
+  location: in-scope truths get Strike / Replace, state entries get Strike
+  / Set. Strikes now feed the CORRECTED do-not-re-assert block and the
+  write-layer re-assertion guard (2026-07).
+- **Medium/low-confidence** results are telemetry-only — logged to the
+  Pacing Telemetry journal's Consistency Check page
+  (`logConsistencyDecision`, GM-gated, fail-open) and never shown to the GM.
+- **`contradictionNotifications`** (default on) gates the card itself; off
+  means even high-confidence catches are telemetry-only.
+- The **WJ lore-contradiction path** (detection pass, `entryType: "lore"`)
+  posts the same card WITHOUT the retract button — WJ lore's correction
+  affordance is the `!journal` command family (reaffirmed 2026-07).
+
+## 3. Verified defects (open — awaiting direction; see `known-issues.md`)
+
+1. **NARRCHK-TRUNC-SILENT** (LOSE-DETECTION): the Haiku audit call caps
+   `max_tokens` at **250** with no `stop_reason` check — a
+   contradiction-rich response truncates mid-JSON; `parseAuditResponse`'s
+   fallback then salvages a partial object or returns `[]`, silently
+   dropping catches. Same failure class as the fixed NARR-SIDECAR-SILENT:
+   invisible truncation at the exact moment the check matters most (the
+   2026-07 scope broadening — six sections, six kinds — made long responses
+   more likely, and 250 tokens is ~3–4 contradiction objects).
+2. **NARRCHK-CTX-DROPPED** (WRONG-DETAIL, small): `narrateOracleFollowup`
+   resolves lexical relevance into `extras.matchedEntityIds` but its
+   `applyNarratorSidecar` ctx omits them — the oracle-follow-up audit
+   can't see entity-scoped ledger entries or matched-NPC identities, so a
+   follow-up that misgenders or contradicts the NPC the question named goes
+   unaudited. (Vignette/vow/inciting sites also omit the field but
+   genuinely match nothing; passing it uniformly costs one argument.)
+3. **NARRCHK-REMEDY-MISMATCH** (design defect): the review card's only
+   affordance is the scene-ledger correction dialog, but four of the six
+   audit kinds can't be remedied there — a **frame** contradiction needs a
+   frame re-emit, a **ship** contradiction lives on the ship record
+   (`!ship` / token move), an **identity** contradiction lives on the actor
+   sheet or connection record, and a **retraction** re-assertion is already
+   write-blocked (the card is informational). The GM clicks "Retract the
+   offending fact" and finds a dialog that cannot address what was flagged.
+
+## 4. Design-level exposure
+
+- **Medium-confidence catches are invisible in play.** Telemetry-only is a
+  deliberate noise-control choice, but it has never been recorded as a
+  decision; if playtests show real drift arriving as "medium", a
+  lower-friction surface (collapsed card, session-end digest) is the
+  direction. Needs a decisions.md line either way.
+- **No cross-turn dedup.** A standing contradiction (prose keeps asserting
+  a struck fact the model refuses to drop) re-posts a review card every
+  narration. The write-layer re-assertion block (2026-07) prevents the
+  ledger damage; the card spam remains.
+- **Superseded-prose review cards linger.** Burn-momentum / improve-result
+  re-narrations audit the NEW prose (correct), but a review card raised
+  against the pre-burn prose stays in the GM's whispers after the
+  supersede — pointing at fiction that no longer stands.
+- **The audit is only as visible as its two toggles**:
+  `factContinuity.consistencyCheck` (on) × `contradictionNotifications`
+  (on). Both default sane; the combination "check on, notifications off" is
+  a silent mode worth a settings-panel hint.
+
+## 5. What held up under audit
+
+Fire-and-forget dispatch (zero latency on the narration post) with
+canonical-GM single-emitter gating; the audit compares against the full
+ledger block including every 2026-07 addition (frame, retractions, ship,
+identities); parsing is tolerant and never blocks; every audit — including
+clean ones — lands in telemetry with elapsed-ms for tuning; the review card
+stays out of narrator memory despite co-marking `narratorCard`; the
+correction dialog scopes to the card's matched entities and re-renders in
+place; and all API traffic rides `api-proxy.js` per the architecture
+constraint.

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -10,6 +10,43 @@ below were verified against source — full traces in `docs/flows/*.md`._
 
 ## Active issues
 
+### Narrator-consistency audit findings (2026-07) — OPEN, awaiting direction
+
+Surfaced by the consistency-check pipeline audit (full trace:
+`docs/flows/narrator-consistency-flow.md`). Verified against source; none
+fixed yet.
+
+| Code | Class | Defect |
+|---|---|---|
+| NARRCHK-TRUNC-SILENT | LOSE-DETECTION | The audit's Haiku call caps `max_tokens` at 250 with no `stop_reason` check — a contradiction-rich response truncates mid-JSON and catches are silently dropped (the 2026-07 six-section broadening made this more likely; 250 tokens ≈ 3–4 contradiction objects) |
+| NARRCHK-CTX-DROPPED | WRONG-DETAIL | Oracle follow-ups resolve `matchedEntityIds` but don't pass them to the sidecar apply ctx — that path's audit can't see entity-scoped ledger entries or matched-NPC identities |
+| NARRCHK-REMEDY-MISMATCH | design defect | The review card's only affordance is the scene-ledger correction dialog, but frame / ship / identity / retraction contradictions (four of six audit kinds) cannot be remedied there |
+
+Design exposure: medium-confidence catches are telemetry-only (undocumented
+decision); no cross-turn dedup (standing contradictions re-post a card every
+narration); pre-burn review cards linger after a supersede; "check on,
+notifications off" is a silent mode — see the flow doc §4.
+
+### Faction lifecycle audit findings (2026-07) — OPEN, awaiting direction
+
+Surfaced by the faction lifecycle audit (full trace:
+`docs/flows/faction-flow.md`). Verified against source; none fixed yet.
+Headline: the assembler context packet — the conduit that was supposed to
+carry World Journal state to the narrator — is dead at every callsite, so
+the narrator has never seen a faction attitude.
+
+| Code | Class | Defect |
+|---|---|---|
+| FACTION-PACKET-DEAD | LOSE-PLOT | `assembleContextPacket`'s 17-section packet (faction landscape, threats, WJ lore, discoveries, session notes, recent oracles, …) is passed to `narrateResolution` at all three callsites and the parameter is **never read**; the interpreter doesn't take it either. The entire packet subsystem is dead on live paths — wider than factions |
+| FACTION-DUAL-STORE | WRONG-DETAIL | A narrator-named faction gets a WJ entry AND (on draft confirm) an entity record — two vocabularies (`attitude` vs `relationship`), no reconciliation, never merged or retired |
+| FACTION-ATTITUDE-SPLIT-BRAIN | WRONG-DETAIL | `attitudeShift` transitions write only the WJ store (unconditionally — no entity gate on the transitions loop), while no narrative path ever updates `record.relationship` — the card the narrator sees shows a stance frozen at confirm time |
+| FACTION-RECORD-WRITE-ONCE | LOSE-PLOT | `updateFaction`/`addRumor`/`setProject`/`setSceneRelevant` have zero callers; `active` never flips; draft-confirmed factions skip oracle seeding — records are frozen at creation apart from generative-tier accrual and manual panel edits |
+| FACTION-DETECTOR-ONLY-CONTEXT | INVENT-RISK | The detection Haiku sees the WJ attitude landscape; the narrator writing the prose does not — stance contradictions are recorded as new shifts instead of prevented |
+
+Design exposure: faction stance has no canonical home (`attitude` vs
+`relationship` vs `sector.faction` name); no dissolution lifecycle — see the
+flow doc §4.
+
 ### Character-detail drift audit findings (2026-07) — all fixed in the v1.7.30 cycle
 
 Surfaced by the character-detail drift audit; every defect and the


### PR DESCRIPTION
## Initiating prompt

&gt; After this, I'd like a the same treatment applied to faction lifecycle and narrator consistency

("Narrator consistency" scoped as the fact-continuity consistency-check pipeline end to end — detection → review card → correction — plus the adjacent WJ lore-contradiction path. Flag if you meant broader narrative consistency and I'll extend the audit.)

## What & why

Two trace-verify-document audits, delivered together. **Analysis only — no source changes; fixes await direction.** Open ledgers in `known-issues.md`.

### Faction lifecycle — `docs/flows/faction-flow.md` (five defects)

| Code | Headline |
|---|---|
| FACTION-PACKET-DEAD | **The narrator has never seen a faction attitude.** `assembleContextPacket`'s 17-section packet (FACTION LANDSCAPE, threats, WJ lore, discoveries, session notes, recent oracles…) is passed to `narrateResolution` at all three callsites — **and the parameter is never read**. The interpreter doesn't take it either. The whole packet subsystem is a Loremaster-era conduit orphaned when narration moved to `buildNarratorSystemPrompt` — the same untested-composition failure shape as CHAR-PC-BLOCK-STARVED, and wider than factions |
| FACTION-DUAL-STORE | A narrator-named faction gets a WJ entry *and* (on confirm) an entity record — two vocabularies (`attitude` 4-value vs `relationship` 8-value), never reconciled or merged |
| FACTION-ATTITUDE-SPLIT-BRAIN | `attitudeShift` transitions write only the WJ store; **no narrative path ever updates `record.relationship`** (`updateFaction` has zero callers) — the entity card the narrator sees shows a stance frozen at confirm time |
| FACTION-RECORD-WRITE-ONCE | `updateFaction`/`addRumor`/`setProject`/`setSceneRelevant`: zero callers. Confirmed factions skip oracle seeding (unlike connections). Records are frozen at creation apart from generative-tier accrual and manual panel edits |
| FACTION-DETECTOR-ONLY-CONTEXT | The detection Haiku is shown the attitude landscape to *classify* transitions — the narrator that *authors* the prose never sees it, so contradictions are recorded rather than prevented |

### Narrator consistency — `docs/flows/narrator-consistency-flow.md` (three defects)

| Code | Headline |
|---|---|
| NARRCHK-TRUNC-SILENT | The audit's Haiku call caps `max_tokens` at **250** with no `stop_reason` check — a contradiction-rich audit truncates mid-JSON and catches drop silently (the 2026-07 six-section broadening made long responses likelier; 250 tokens ≈ 3–4 contradiction objects) |
| NARRCHK-CTX-DROPPED | Oracle follow-ups resolve `matchedEntityIds` but don't pass them to the apply ctx — that path's audit misses entity-scoped ledger entries and matched-NPC identities |
| NARRCHK-REMEDY-MISMATCH | The review card's one affordance is the scene-ledger correction dialog — but frame / ship / identity / retraction contradictions (four of the six audit kinds) can't be remedied there |

Design exposures recorded alongside: faction stance has no canonical home; medium-confidence catches are telemetry-only (undocumented decision); no cross-turn dedup of standing contradictions; pre-burn review cards linger after a supersede.

**What held up:** immediate WJ surfacing for new factions, the entity-gate on the new-faction loop, faction entity cards + generative-tier accrual, fire-and-forget audit dispatch with canonical-GM gating, the full-ledger audit scope, tolerant parsing, per-audit telemetry, and the ring's defensive excludes on the review card.

## Testing

Docs-only: `npm test` — 2961 passing (118 files); `npm run lint` — 0 errors. The e2e docs-only fast path applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nD9TZKAeTWpfVXcFVgU63

---
_Generated by [Claude Code](https://claude.ai/code/session_011nD9TZKAeTWpfVXcFVgU63)_