### PR TITLE
docs: vault & derelict site audit — six verified defects

### DIFF
--- a/docs/flows/site-flow.md
+++ b/docs/flows/site-flow.md
@@ -1,0 +1,128 @@
+# Vault & derelict (site) flow — as implemented
+
+How precursor vaults and derelicts are generated, hidden, discovered, and
+explored — verified against source (v1.7.30 cycle). Sibling docs:
+`exploration-flow.md` (expeditions, waypoints, ship position),
+`narrator-context-flow.md` (the context surfaces site details ride on).
+
+Prompted by: "Can you review the Vault and Derelict creation and exploration
+flow?" §3 is the open defect ledger (fixes await direction). Tags:
+**LOSE-CONTENT** (shipped content unreachable), **WRONG-DETAIL**,
+**LOSE-PLOT**, **LOSE-PAYOFF**.
+
+## 1. Creation — sector generation only
+
+`generateSectorSites(region, trouble)` (`src/sectors/precursorSites.js`,
+pure + unit-tested) plans a region-scaled site count (terminus 1 /
+outlands 2 / expanse 3, alternating derelict-first) plus one themed bonus
+site when the sector trouble keyword-matches precursor ("vault") or
+wreck/ghost ("derelict") wording. Each site rolls the full canonical oracle
+spread:
+
+- **Vault**: location, scale, form, shape, material, outer + inner first
+  look, purpose, interior feature / peril / opportunity — name
+  `Precursor Vault — <Form>`.
+- **Derelict**: location, type, condition, outer + inner first look, one
+  notable zone (starship vs settlement zone table by rolled type) — name
+  from the type, Roman-numeral deduped within the sector.
+
+`buildSiteLocationData` shapes each site for `createLocation` — a
+`location`-type Actor with `system.subtype` vault/derelict,
+`canonicalLocked: true` (narrator entity-discovery can never overwrite),
+`status: "unexplored"`, and a `description` that bakes the exterior AND
+interior prep into one field. A parallel discovery record
+(`{id, name, type, discovered:false, actorId}`) lands on the sector's
+`mapData.discoveries[]`, and the scene builder places a dim, unlabelled pin
+behind an undiscovered passage — players see *something* is out there, not
+what.
+
+## 2. Discovery
+
+Two reveal paths, both funnelling through `revealSectorSite`
+(`src/sectors/siteDiscovery.js`, dependency-injected, GM-gated by callers):
+
+1. **Finishing an expedition** whose track was stamped with a `siteId` FK at
+   creation (`requireLabelMatch` — no guessing) or whose label fuzzy-matches
+   (`selectSiteForReveal`: exact → substring → type-keyword-when-unique →
+   sole-undiscovered). The reveal mutates the in-memory campaignState so the
+   pending `persistResolution` write carries it.
+2. **`!reveal-site <name>`** — manual, GM-only, with the same ladder.
+
+Revealing flips `discovered`, sets the location Actor `status: "visited"`,
+restyles the scene pin + passage to charted appearance, persists, and posts
+the **◈ Site Discovered** card ("undertake an expedition there, or Explore
+a Waypoint to move through its zones").
+
+## 3. Verified defects (open — awaiting direction; see `known-issues.md`)
+
+1. **SITE-ZONE-TABLES-DEAD** (LOSE-CONTENT): `tables/derelicts.js` ships
+   **20** canonical tables; the roller registers **7**. The entire derelict
+   zone-crawl suite — `ACCESS_AREA` / `ACCESS_FEATURE` / `ACCESS_PERIL` /
+   `ACCESS_OPPORTUNITY` plus the seven per-zone AREA tables (community,
+   engineering, living, medical, operations, production, research) — is
+   unreachable from every affordance: no oracle id, no `!oracle` reach, no
+   waypoint button, no exploration seed. The rulebook's derelict exploration
+   loop (pick a zone → roll Area → Feature → Peril/Opportunity on trouble)
+   has its data in-tree and dead.
+2. **SITE-WAYPOINT-BLIND** (WRONG-DETAIL): the discovery card tells the
+   player to "Explore a Waypoint to move through its zones," but
+   `explore_a_waypoint`'s oracle seeds are site-agnostic — action + theme,
+   plus Make a Discovery / Confront Chaos on matches. Exploring INSIDE a
+   derelict or vault never rolls the site's zone/interior tables and never
+   tells the narrator what kind of site the waypoint belongs to. The vault
+   interior feature/peril/opportunity tables ARE registered — but they are
+   rolled exactly once at generation as static prep; the exploration loop
+   (rulebook: roll fresh interior results per area explored) never touches
+   them again.
+3. **SITE-ANCHOR-ABSENT** (LOSE-PLOT): `formatActiveSector` lists
+   settlements only. A **discovered** site never joins the standing sector
+   picture — the narrator learns it exists only when the player types its
+   exact name (lexical relevance) or after arrival sets it current. Between
+   discovery and arrival, prose about "the derelict" matches nothing
+   ("Derelict Starship II" ≠ "the derelict"), so the narrator can invent
+   details that contradict the rolled prep it was never shown.
+4. **SITE-TYPE-TABLE-MISMATCH** (canon fidelity, minor): `derelict_type` is
+   registered to `TYPE_DEEP_SPACE` unconditionally; `TYPE_PLANETSIDE` and
+   `TYPE_ORBITAL` exist in the table file, unregistered and unused.
+   `generateDerelictSite` rolls the location first and then types every
+   derelict with deep-space weights — canonically the type table varies by
+   location (planetside derelicts skew settlement).
+5. **SITE-DISCOVERY-CARD-GENERIC** (LOSE-PAYOFF, minor): the Site
+   Discovered card announces "a passage opens through to a precursor vault"
+   without the site's rolled exterior — condition, scale/form, outer first
+   look. The payoff moment shows none of the prep; the GM has to open the
+   location record to narrate the approach.
+6. **SITE-NO-COMPLETION** (minor): the location schema documents
+   `status: "cleared"` but nothing ever sets it — the lifecycle stops at
+   `visited` (set on reveal, before anyone has even boarded). Nothing
+   distinguishes glimpsed-from-orbit from fully-delved, and no affordance
+   closes a site.
+
+## 4. Design-level observations
+
+- **Interior prep is baked into one description field** — outer and inner
+  first looks, purpose, notable zone all concatenate into
+  `location.description`, so the narrator (via the CURRENT LOCATION card or
+  a matched entity card) reads the interior before the crew breaches the
+  airlock. Acceptable as GM-brain prep — the narrator should pace
+  revelation — but there is no staged outer/inner reveal if drift shows up
+  in play.
+- **No zone-position state.** Exploration depth inside a site is purely
+  fictional (no "current zone" tracking). Fine for Starforged — it has no
+  delve mechanic — but the dead zone tables (§3.1) suggest the richer crawl
+  was the original intent.
+
+## 5. What held up under audit
+
+Creation is pure, canonical, and unit-tested (region scaling, trouble
+theming, full oracle spreads, name dedup); sites are `canonicalLocked` so
+entity discovery never overwrites them; pins stay unlabelled until
+discovery, and the sector anchor's settlement-only roster means undis-
+covered sites leak nowhere; the expedition→site link is stamped strictly
+(`requireLabelMatch`) and revealed precisely (`siteId` FK with the fuzzy
+ladder as fallback — the 2026-07 soft-spot fixes); `!reveal-site` is
+GM-gated with a not-found notice; the reveal updates record + pin + state
+in one pass, tolerating per-step failures; and arrival by move sets
+`currentLocationId` for location-type entities (LOCATION-DUAL-STORE fix),
+so a named site becomes the CURRENT LOCATION card with its full record the
+moment the crew actually goes there.

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -10,6 +10,24 @@ below were verified against source — full traces in `docs/flows/*.md`._
 
 ## Active issues
 
+### Vault & derelict (site) audit findings (2026-07) — OPEN, awaiting direction
+
+Surfaced by the site creation/exploration audit (full trace:
+`docs/flows/site-flow.md`). Verified against source; none fixed yet.
+Creation and discovery are solid; the gaps are all on the exploration side.
+
+| Code | Class | Defect |
+|---|---|---|
+| SITE-ZONE-TABLES-DEAD | LOSE-CONTENT | `tables/derelicts.js` ships 20 canonical tables; the roller registers 7 — the whole derelict zone-crawl suite (ACCESS area/feature/peril/opportunity + seven per-zone AREA tables) is unreachable from any affordance |
+| SITE-WAYPOINT-BLIND | WRONG-DETAIL | The discovery card says "Explore a Waypoint to move through its zones," but `explore_a_waypoint` seeds are site-agnostic; vault interior tables are registered yet rolled only once at generation — the exploration loop never rolls fresh interior/zone results |
+| SITE-ANCHOR-ABSENT | LOSE-PLOT | `formatActiveSector` lists settlements only — a discovered site never joins the standing sector picture, so "the derelict" in prose matches nothing and the narrator can contradict prep it was never shown |
+| SITE-TYPE-TABLE-MISMATCH | canon fidelity | `derelict_type` always uses the deep-space weights; `TYPE_PLANETSIDE`/`TYPE_ORBITAL` exist unregistered — planetside derelicts should skew settlement |
+| SITE-DISCOVERY-CARD-GENERIC | LOSE-PAYOFF | The Site Discovered card omits the rolled exterior (condition, scale/form, outer first look) — the payoff moment surfaces none of the prep |
+| SITE-NO-COMPLETION | minor | `status: "cleared"` is documented but never set; the lifecycle stops at `visited` (stamped on reveal, pre-boarding) with no way to close a site |
+
+Design observations: interior prep bakes into one description field (no
+staged outer/inner reveal); no zone-position state — see the flow doc §4.
+
 ### Narrator-consistency audit findings (2026-07) — all fixed in the v1.7.30 cycle
 
 Surfaced by the consistency-check pipeline audit; all three defects and the


### PR DESCRIPTION
## Initiating prompt

&gt; Can you review the Vault and Derelict creation and exploration flow?

## What & why

The same trace-verify-document treatment applied to precursor vaults and derelicts: generation, hiding, discovery, and in-site exploration, every claim verified against source.

**New `docs/flows/site-flow.md`** — creation pipeline (region-scaled + trouble-themed planning, full canonical oracle spreads, hidden pins, `mapData.discoveries`), the two reveal paths (expedition-FK + `!reveal-site`), and the exploration surfaces.

**`known-issues.md`** gains the open ledger — **six verified defects, awaiting direction**. Creation and discovery held up well; every defect is on the exploration side:

| Code | Headline |
|---|---|
| SITE-ZONE-TABLES-DEAD | **The derelict zone-crawl content is shipped and dead.** `tables/derelicts.js` has 20 canonical tables; the roller registers 7 — the ACCESS area/feature/peril/opportunity suite and all seven per-zone AREA tables are unreachable from any affordance |
| SITE-WAYPOINT-BLIND | The discovery card says "Explore a Waypoint to move through its zones" — but `explore_a_waypoint` seeds are site-agnostic, and the (registered) vault interior tables are rolled exactly once at generation; the exploration loop never rolls fresh interior/zone results |
| SITE-ANCHOR-ABSENT | A **discovered** site never joins the ACTIVE SECTOR picture (settlements only) — prose about "the derelict" matches nothing, so the narrator can contradict prep it was never shown |
| SITE-TYPE-TABLE-MISMATCH | `derelict_type` always rolls deep-space weights; the planetside/orbital type tables exist unregistered (planetside derelicts should skew settlement) |
| SITE-DISCOVERY-CARD-GENERIC | The Site Discovered card omits the rolled exterior — the payoff moment surfaces none of the prep |
| SITE-NO-COMPLETION | `status: "cleared"` is documented but never set; the lifecycle stops at `visited`, stamped on reveal before anyone boards |

**What held up:** the pure, unit-tested creation pipeline; `canonicalLocked` protection; unlabelled pins + settlement-only sector anchor (no pre-discovery leak); the strict expedition→site FK stamping and precise `siteId` reveal (2026-07 soft-spot fixes); GM-gated `!reveal-site`; and arrival-by-move setting the site as CURRENT LOCATION with its full record.

**No source changes** — analysis only; fixes await direction.

## Testing

Docs-only: `npm test` — 2978 passing (119 files); `npm run lint` — 0 errors. The e2e docs-only fast path applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nD9TZKAeTWpfVXcFVgU63

---
_Generated by [Claude Code](https://claude.ai/code/session_011nD9TZKAeTWpfVXcFVgU63)_