### PR TITLE
docs: codify the invisible-invariant bug families in the rules (reachability, drift, identity, reload)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,30 @@ you to address a specific one in the current session conversation.
   `tests/`, and `src/integration/quench.js` — and update them in the same
   commit. Three of the four v1.7.6 playtest bugs came from one unaudited
   type-meaning change (NPCs becoming `character` actors).
+- **Verify reachability when adding; keep mirrors write-through.** A producer
+  with zero consumers is a bug, not a feature — before committing a new exported
+  function, registered oracle table, oracle id, setting, chat command, card
+  flag, or schema field, grep for what consumes it and confirm the wiring hop
+  exists (authoring a table is not registering it; writing a builder is not
+  calling it). Zero consumers → delete it, wire it, or mark `// UNWIRED:
+  <who/when>` + a `known-issues.md` line. When a refactor supersedes an old
+  path, delete the old path in the same commit — inert-but-present is a latent
+  bug (`FACTION-PACKET-DEAD`'s dead `packet` param silently aborted
+  re-narration). And when one fact lives in two stores, name the canonical one
+  and write through to the mirror on **every** change — never leave two stores
+  independently writable (`BOND-ITEM-MIRROR`, `LOCATION-DUAL-STORE`,
+  `FACTION-DUAL-STORE`). This produced-but-dead / mirror-drift family is the
+  repo's most persistent bug class — full rules in `rules/reachability.md`.
+- **Verify reachability when adding:** a producer with zero consumers is a bug,
+  not a feature. Before committing a new exported function, registered oracle
+  table, oracle id, setting, chat command, card flag, or schema field, grep for
+  what consumes it and confirm the wiring hop exists — authoring a table is not
+  registering it; writing a builder is not calling it. Zero consumers → delete
+  it, wire it in the same commit, or mark it `// UNWIRED: <who/when>` **and** add
+  a `known-issues.md` line. When a refactor supersedes an old path, delete the
+  old path in the same commit (inert-but-present is a latent bug, not a
+  courtesy). Six v1.7.30 audits each found a shipped-but-dead feature that passed
+  tests and lint — see `rules/reachability.md`.
 - **Settled decisions: search, don't re-derive.** If the user says a decision
   was already made, find it (`decisions.md`, the scope **issue** on GitHub,
   `docs/testing/*playtest-findings*`) before re-opening it. If a doc or issue
@@ -114,6 +138,13 @@ edits, other config tidy-ups, reformatting, stray debug logging. "While I'm
 here" config changes need their own explicit go-ahead and never ride along
 inside a feature commit (a `.claude/`-ignore edit bundled into the
 clocks/vignettes commit had to be unwound exactly this way).
+
+**Reachability check.** For any new producer in the diff (exported function,
+registered table, oracle id, setting, command, card flag, schema field), grep
+its consumer and confirm the wiring hop exists; for any write to a mirrored
+fact, confirm every store is updated. Tests and lint are blind to both — see
+`rules/reachability.md`. A zero-consumer add or an unmirrored write is a defect
+even with a green gate.
 
 Commit message format:
 ```
@@ -314,7 +345,19 @@ These are deliberate decisions — do not change without reading
   the v1 `Application` class.
 - No jQuery. DOM API only (`querySelector`, `createElement`, `addEventListener`).
 - `game.settings` world-scoped writes require GM permissions. Player-triggered
-  actions that need to persist state must use a GM-check gate.
+  actions that need to persist state must use a GM-check gate. Two sharper
+  distinctions the repo has had to fix repeatedly (multiplayer/GM handling is
+  its third-most-common bug family):
+  - **Single-emitter writes gate on `isCanonicalGM()`, not `game.user.isGM`.**
+    Anything that posts a shared document or persists world state from the
+    pipeline (ledger writes, the rolling-summary persist, contradiction cards)
+    must be canonical-GM-gated so a two-GM table doesn't double-emit or race.
+    Plain `isGM` is only for a local, idempotent read.
+  - **Credit the roller, not the GM.** Move effects (momentum, meter changes,
+    XP) apply to the player who rolled — resolve the acting actor from the chat
+    speaker, never `game.user.character` or "first PC in campaignState." The
+    inciting/founding vow is the one shared exception (see decisions.md →
+    "Multiplayer attribution").
 - Concurrency guards and pipeline locks (e.g. `campaignState.pendingMove`, an
   ApplicationV2's `busy` flag) must be released in a `finally`, never on the
   happy path alone. An exception — or an awaited promise that never settles —
@@ -353,4 +396,8 @@ Topic-specific rules are split out under `rules/`. Read on demand:
 - `rules/narrator-memory.md` — narrator memory invariants (flag-family
   contract, sidecar contract, never-dropped tiers); full architecture +
   tuning guide in `docs/narrator/narrator-memory-architecture.md`
+- `rules/reachability.md` — the repo's most persistent bug class: produced-but-
+  dead features and mirror-store drift (both pass tests + lint). The
+  reachability gate, teardown rule, composition test, no-speculative-surface,
+  and single-source-of-truth write-through rule
 - `rules/project-context.md` — module overview, transport, system dependency

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,8 +396,10 @@ Topic-specific rules are split out under `rules/`. Read on demand:
 - `rules/narrator-memory.md` — narrator memory invariants (flag-family
   contract, sidecar contract, never-dropped tiers); full architecture +
   tuning guide in `docs/narrator/narrator-memory-architecture.md`
-- `rules/reachability.md` — the repo's most persistent bug class: produced-but-
-  dead features and mirror-store drift (both pass tests + lint). The
-  reachability gate, teardown rule, composition test, no-speculative-surface,
-  and single-source-of-truth write-through rule
+- `rules/reachability.md` — the invisible-invariant bug families that pass
+  tests + lint: produced-but-dead features, mirror-store drift,
+  identity-by-mutable-name, and reload/reconnect state loss. The reachability
+  gate, teardown rule, composition test, no-speculative-surface,
+  single-source-of-truth write-through, resolve-by-stable-id, and
+  survive-reload rules
 - `rules/project-context.md` — module overview, transport, system dependency

--- a/rules/reachability.md
+++ b/rules/reachability.md
@@ -101,12 +101,56 @@ six times.
   fact mirrored with no decision naming the winner is a drift bug waiting to
   happen — record the decision first.
 
+## 6. Resolve identity by stable id, not by mutable display name
+
+Match entities on a persistent id (`vowId`, `siteId`, `connectionId`,
+`entityId`), not on a name or label a player can rename or that can collide. A
+name/label match is a *fallback* below the id, and it must never mint a
+duplicate or silently hit the wrong target.
+
+- `EXPEDITION-FINISH-TARGET` revealed the wrong site because finish matched by
+  the expedition's *label*; fixed by stamping a `siteId` FK at creation and
+  revealing that exact discovery. `VOW-RENAME-PAYOFF` lost the fulfilment
+  payoff when a vow was renamed, because the payoff matched by name; fixed by
+  resolving vow copies `vowId`-first. `FOLDER-001` spawned a duplicate sector
+  folder every load because "does this folder exist?" matched loosely.
+  Placeholder figures were duplicated instead of renamed in place until the
+  detector matched the existing record.
+- When only a name is available (narrator prose, a chat command), use a
+  **bounded ladder** — exact → substring → type-keyword-when-unique →
+  sole-open — and **stop before guessing** when a wrong guess is costly
+  (`requireLabelMatch` on the expedition→site stamp is exactly this: no
+  sole-open fallback when *creating* a link, only when *revealing*). A rename
+  or an ambiguous name must never fan a write to the wrong record.
+
+## 7. World state must survive reload and reconnect
+
+Foundry reloads the world and reconnects clients constantly. Anything created
+per-session must be idempotent on reload, and transient locks must reset.
+
+- **Creation guards against re-creating.** `FOLDER-001` (duplicate sector
+  folders each load) and "settled settlements moved to Unsorted on reload"
+  were both reload re-runs that didn't check for the existing document first.
+  A "create the folder / entity" path must be get-or-create keyed on a stable
+  id, never an unconditional create.
+- **Transient locks reset on `ready`.** A `pendingMove` / `busy` guard
+  persisted in world state wedges every later action after a mid-move reload
+  (`PLAYTEST-1712 P` — a stale lock triggered a spurious roll). Clear in-flight
+  pipeline locks on world ready; see also the `finally`-release constraint in
+  CLAUDE.md.
+- **Client-local state re-derives on reconnect.** Audio autoplay, PTT, and
+  keyed-GM presence are per-client — persist what must survive (autoplay state
+  across reconnect) and re-advertise / re-register the rest on `ready`; never
+  assume a socket peer's memory carried over.
+
 ## The through-line
 
 `npm test` and `npm run lint` both signal "done" and both are blind to
-reachability and to mirror drift. A **flow trace** — following a value from
-source until it reaches a sink (or dangles), and following a fact's writes to
-every store (or misses one) — is the one verification act that catches this
-class, which is why the `docs/flows/*-flow.md` audits found every instance.
-When you add a feature to a flow, update that flow doc's injection/consumption
-map in the same commit: naming the consumer (and every store) *is* the gate.
+reachability, mirror drift, identity resolution, and reload survival — every
+rule here guards a property the gate cannot see. A **flow trace** — following a
+value from source until it reaches a sink (or dangles), and following a fact's
+writes to every store (or misses one) — is the one verification act that
+catches this class, which is why the `docs/flows/*-flow.md` audits found every
+instance. When you add a feature to a flow, update that flow doc's
+injection/consumption map in the same commit: naming the consumer (and every
+store) *is* the gate.

--- a/rules/reachability.md
+++ b/rules/reachability.md
@@ -1,0 +1,112 @@
+# Wiring & data integrity — the dead-feature & drift never-break list
+
+A commit-history review (462 commits, 52 `fix:`) found two bug families that
+recur across the *entire* project life — from the earliest F-series playtests
+through the T1/T3 entity→Actor migration to the v1.7.30 flow audits — and that
+**pass both `npm test` and `npm run lint` every time**. They are two halves of
+one concern: a write or a value that never reaches where it needs to.
+
+- **Reachability (read side):** something is produced but nothing consumes it.
+  `SITE-ZONE-TABLES-DEAD` (13 tables authored, never registered),
+  `FACTION-PACKET-DEAD` (a 17-section packet passed to a parameter nothing
+  read), `writeSessionLog` (implemented, never called — F18),
+  `CHAR-PC-BLOCK-STARVED` (correct producer + consumer, narrowing adapter
+  between), the "surface X to the World Journal / narrator" fixes (Soulbinders
+  gap, PROGRESS TRACKS empty, faction descriptions), `FACTION-RECORD-WRITE-ONCE`
+  (exported helpers, zero callers).
+- **Data integrity (write side):** one fact lives in two stores and a write
+  updates only one. `BOND-ITEM-MIRROR`, `NARR-BOND-RANK-STALE`,
+  `LOCATION-DUAL-STORE`, `FACTION-DUAL-STORE` / `FACTION-ATTITUDE-SPLIT-BRAIN`,
+  `VOW-FULFIL-SIBLINGS`, and the T1/F3 "write to the Actor, not a dead journal
+  page" migration.
+
+Root cause: **reachability and mirror-consistency are invisible properties no
+gate checks.** A producer verifies locally; whether anything consumes it — or
+whether its mirror still agrees — needs a whole-codebase sweep that
+turn-scoped edits skip. These rules make both visible and gateable.
+
+## 1. Reachability gate — nothing ships without a consumer
+
+Before committing a **new** exported function, registered oracle table, oracle
+id, world setting, chat command, card flag, or schema field: grep for what
+consumes it and confirm the hop that makes it reachable exists.
+
+- **A producer with zero consumers is a bug, not a feature.** Delete it, wire
+  it in the same commit, or — if it is a deliberate public API or future hook
+  — mark it `// UNWIRED: <who wires it, when>` **and** add a `known-issues.md`
+  line. No silent zero-consumer additions.
+- The last hop is a *different act* in a *different file*: authoring a table is
+  not registering it (`oracles/roller.js`), writing a builder is not calling
+  it, adding a setting is not reading it. The prompt's named artifact is done
+  when it is **reachable**, not when it **exists**.
+- Creation-side twin of CLAUDE.md's "audit consumers when meaning changes" —
+  same grep, same same-commit discipline, extended from *on change* to *on
+  create*.
+
+## 2. Teardown — a superseded path is deleted, not left inert
+
+When a refactor introduces a path that supersedes an old one, remove the old
+path in the **same commit**. A green suite after deletion is the proof it was
+dead; leaving it is not neutral.
+
+- `FACTION-PACKET-DEAD` left `narrateResolution`'s `packet` parameter and its
+  callsite assembly after narration moved to `buildNarratorExtras`; the inert
+  `if (!packet) return` guard then silently aborted burn/improve re-narration.
+  The safe-looking choice (leave the old path) *was* the bug.
+- Additive-only refactors are how you get two paths where one is dead —
+  deletion anxiety is the enemy here, not the safeguard.
+
+## 3. Test the composition, not just the units
+
+For any producer → adapter → consumer chain where the adapter transforms or
+narrows, at least one test must exercise the **live composition** — the real
+`getActiveCharacter → buildNarratorSystemPrompt`, not
+`buildCharacterBlock(handBuiltObject)`.
+
+- `CHAR-PC-BLOCK-STARVED` survived for months *because* `buildCharacterBlock`
+  had thorough unit tests fed hand-built full objects. The starving happened in
+  the seam nothing exercised. A green unit test proves "this unit works in
+  isolation" — it is structurally blind to whether the unit is wired.
+
+## 4. No speculative API surface
+
+Write the caller and the callee in the same change, or don't write the callee.
+
+- `updateFaction` / `addRumor` / `setProject` / `setSceneRelevant` were all
+  exported, all zero-caller — a "complete-looking" entity API written ahead of
+  callers that never came.
+- A genuinely-wanted API ahead of its callers is a decision → `decisions.md` +
+  an `// UNWIRED:` marker, not a silent export.
+
+## 5. Single source of truth — mirrors are write-through, never independent
+
+When one fact lives in two places (a vendor-sheet Item mirroring an entity
+record; a World Journal entry beside an entity record; a journal page beside an
+Actor flag), declare **one** canonical store and make the other a write-through
+mirror updated on **every** change to the canonical value. Two independently
+writable stores of one fact will drift — the repo has re-learned this at least
+six times.
+
+- The failure is always identical: a *new* write path updates canon and forgets
+  the mirror (`BOND-ITEM-MIRROR`, `NARR-BOND-RANK-STALE`), or updates a mirror
+  the reader doesn't consult (`LOCATION-DUAL-STORE` — travel-by-move set the
+  ship position but not `currentLocationId`), or updates one copy of a fanned
+  fact (`VOW-FULFIL-SIBLINGS` — paid one vow copy, not its shared siblings).
+- When you add a write to a mirrored fact, grep for **every** store of that
+  fact and update all of them, or route the write through the one function that
+  fans out (`setBondItemTicks` / `setBondItemRank`; `recordFactionIntelligence`
+  syncs `record.relationship` from the WJ attitude).
+- `decisions.md` must name the canonical store per fact ("Faction stance: the
+  entity record is canonical"; "Progress tracks: single dedicated journal"). A
+  fact mirrored with no decision naming the winner is a drift bug waiting to
+  happen — record the decision first.
+
+## The through-line
+
+`npm test` and `npm run lint` both signal "done" and both are blind to
+reachability and to mirror drift. A **flow trace** — following a value from
+source until it reaches a sink (or dangles), and following a fact's writes to
+every store (or misses one) — is the one verification act that catches this
+class, which is why the `docs/flows/*-flow.md` audits found every instance.
+When you add a feature to a flow, update that flow doc's injection/consumption
+map in the same commit: naming the consumer (and every store) *is* the gate.


### PR DESCRIPTION
## Initiating prompt

&gt; A lot of recent prs were Fable identifying shipped-but-dead or unwired features. What is the root cause of this type of behavior in Opus prompts, and how can we reinforce the rules to do better?
&gt; Please update the rules. Additionally, are there other known failure patterns that show up consistently in this repo's history?
&gt; Please go deeper and review commit history
&gt; Please add them too

## What & why

A commit-history review (462 commits; 52 `fix:`, plus the F-series playtest ledger) identified the recurring bug families that **pass `npm test` and `npm run lint` every time** because they guard properties no gate can see. Root cause: a coding turn closes on "the named artifact looks complete and tests pass," and both signals are structurally blind to reachability, mirror consistency, identity resolution, and reload survival — each needs a whole-codebase sweep the turn skips. The lever isn't prompt wording; it's making those invisible properties gateable.

### `rules/reachability.md` (new) — seven rules, each anchored to its motivating finding

1. **Reachability gate** — no producer ships without a consumer; grep on *create*, not just on meaning-change (`SITE-ZONE-TABLES-DEAD`, `writeSessionLog` never called).
2. **Teardown** — a superseded path is deleted in the same commit (`FACTION-PACKET-DEAD`'s inert `if (!packet) return` silently aborted re-narration).
3. **Composition test** — exercise the live producer→adapter→consumer chain (`CHAR-PC-BLOCK-STARVED` hid in the untested seam for months).
4. **No speculative API surface** (`updateFaction`/`addRumor`/`setProject` — exported, zero callers).
5. **Single source of truth** — mirrors are write-through; `decisions.md` names the canonical store (`BOND-ITEM-MIRROR`, `LOCATION-DUAL-STORE`, `FACTION-DUAL-STORE`).
6. **Resolve identity by stable id, not mutable display name** — id first, name a bounded fallback that stops before guessing when costly (`EXPEDITION-FINISH-TARGET`, `VOW-RENAME-PAYOFF`, `FOLDER-001`, placeholder rename-in-place).
7. **Survive reload and reconnect** — get-or-create keyed on a stable id, transient locks reset on `ready`, client-local state re-derives on reconnect (`FOLDER-001`, settlements-to-Unsorted, `PLAYTEST-1712 P` stale move lock).

### `CLAUDE.md`
- A "**verify reachability when adding; keep mirrors write-through**" autonomy bullet (sibling to the existing "audit consumers when meaning changes").
- A **pre-commit reachability check** in the Before-every-commit section.
- A **canonical-GM + credit-the-roller** architecture constraint (the third-most-common family, 24 commits: single-emitter writes gate on `isCanonicalGM()` not `game.user.isGM`; move effects credit the roller).
- The `rules/reachability.md` pointer, naming all four invisible-invariant families.

Families already covered by existing rules — pipeline lock-ups (`finally`-release constraint) and silent-failure (the "No silent failures" decision) — were left as-is rather than duplicated; recurrence there is an enforcement gap, not a missing rule.

## Testing

Docs/rules only, no code. `npm test` — 2990 passing; `npm run lint` — 0 errors. e2e docs-only fast path applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nD9TZKAeTWpfVXcFVgU63

---
_Generated by [Claude Code](https://claude.ai/code/session_011nD9TZKAeTWpfVXcFVgU63)_